### PR TITLE
Reorganize and document files related to structural elements

### DIFF
--- a/src/.prototype/syntaxElements/@types/structureElements.d.ts
+++ b/src/.prototype/syntaxElements/@types/structureElements.d.ts
@@ -1,42 +1,87 @@
 import { TPrimitive, TPrimitiveName } from './primitiveTypes';
 
-/** An object whose class implements this will be tied to the corresponding UI element. */
+/**
+ * There are two categories of syntax elements: Arguments and Instructions.
+ *
+ * Arguments are of two kinds: Data (simply store a value), and Expressions (take other values as
+ * arguments and operate on them to return another value).
+ *
+ * Instructions are of two kinds: Statements (a single linear instruction), and Blocks (wrap around
+ * other instructions while performing some actions before and after executing them).
+ */
+
+/** Objects whose classes implement this will be tied to the corresponding UI element. */
 export interface ISyntaxElement {
+    /** Name of the supported syntax element. Different from identifiers. */
     elementName: string;
 }
 
 export interface IDataElement {
+    /** A primitive element. */
     data: TPrimitive;
 }
 
 export interface IExpressionElement {}
 
-export interface IArgumentElement extends ISyntaxElement {
-    type: 'data' | 'expression';
-    returnType: TPrimitiveName;
-    data: TPrimitive;
-}
-
-export interface IArgumentDataElement extends ISyntaxElement, IDataElement {}
-
-export interface IArgumentExpressionElement extends ISyntaxElement, IExpressionElement {
-    args: Object;
-}
-
+/**
+ * To be implemented by the class that handles the argument interface for classes that implement
+ * IArgumentExpressionElement or IInstructionElement.
+ */
 export interface IArgumentMap {
+    /** Returns the list of argument labels. */
     argNames: string[];
+    /** Assigns an ArgumentElement | null corresponding to an argument label. */
     setArg: Function;
+    /** Returns the ArgumentElement | null corresponding to an argument label. */
     getArg: Function;
 }
 
-interface IInstructionElement extends ISyntaxElement {
+/** To be implemented by the super-class of all argument elements. */
+export interface IArgumentElement extends ISyntaxElement {
+    /** Whether data argument element or expression argument element. */
+    argType: 'data' | 'expression';
+    /** Return type of the argument element. */
+    type: TPrimitiveName;
+    /** Returns the primitive element that the argument element returns. */
+    data: TPrimitive;
+}
+
+/**
+ * To be implemented by sub-classes of class that implement IArgumentElement and represent data
+ * arguments.
+ */
+export interface IArgumentDataElement extends ISyntaxElement, IDataElement {}
+
+/**
+ * To be implemented by sub-classes of class that implement IArgumentElement and represent
+ * expression arguments.
+ */
+export interface IArgumentExpressionElement extends ISyntaxElement, IExpressionElement {
+    /** Stores an object of the class that implements IArgumentMap. */
     args: IArgumentMap;
+}
+
+/** To be implemented by the super-class of all instruction elements. */
+interface IInstructionElement extends ISyntaxElement {
+    /** Stores an object of the class that implements IArgumentMap. */
+    args: IArgumentMap;
+    /** Stores the reference to the next instruction in stack. */
     next: IInstructionElement | null;
 }
 
+/**
+ * To be implemented by sub-classes of class that implement IInstructionElement and represent
+ * non-clamp instructions.
+ */
 export interface IStatementElement extends IInstructionElement {}
 
+/**
+ * To be implemented by sub-classes of class that implement IInstructionElement and represent clamp
+ * instructions.
+ */
 export interface IBlockElement extends IInstructionElement {
+    /** Stores the references to the head instruction inside the logical code block/s. */
     childHeads: (IInstructionElement | null)[];
+    /** Initial head instruction. */
     childHead: IInstructionElement | null;
 }

--- a/src/.prototype/syntaxElements/structureElements.test.ts
+++ b/src/.prototype/syntaxElements/structureElements.test.ts
@@ -35,35 +35,35 @@ describe('class ArgumentDataElement', () => {
     test('intialize object with a TInt(5) and verify contents', () => {
         argData_int = new CArgumentDataElement('myArgData', new TInt(5));
         expect(argData_int.elementName).toBe('myArgData');
-        expect(argData_int.type).toBe('data');
+        expect(argData_int.argType).toBe('data');
         expect(argData_int.data.value).toBe(5);
     });
 
     test('intialize object with a TFloat(3.14) and verify contents', () => {
         argData_float = new CArgumentDataElement('myArgData', new TFloat(3.14));
         expect(argData_float.elementName).toBe('myArgData');
-        expect(argData_float.type).toBe('data');
+        expect(argData_float.argType).toBe('data');
         expect(argData_float.data.value).toBe(3.14);
     });
 
     test('intialize object with a TChar(65) and verify contents', () => {
         argData_char = new CArgumentDataElement('myArgData', new TChar(65));
         expect(argData_char.elementName).toBe('myArgData');
-        expect(argData_char.type).toBe('data');
+        expect(argData_char.argType).toBe('data');
         expect(argData_char.data.value).toBe('A');
     });
 
     test('intialize object with a TString("str") and verify contents', () => {
         argData_string = new CArgumentDataElement('myArgData', new TString('str'));
         expect(argData_string.elementName).toBe('myArgData');
-        expect(argData_string.type).toBe('data');
+        expect(argData_string.argType).toBe('data');
         expect(argData_string.data.value).toBe('str');
     });
 
     test('intialize object with a TBoolean(false) and verify contents', () => {
         argData_boolean = new CArgumentDataElement('myArgData', new TBoolean(false));
         expect(argData_boolean.elementName).toBe('myArgData');
-        expect(argData_boolean.type).toBe('data');
+        expect(argData_boolean.argType).toBe('data');
         expect(argData_boolean.data.value).toBe(false);
     });
 });
@@ -72,8 +72,8 @@ describe('class ArgumentExpressionElement', () => {
     test('initialize object with valid arbitrary arguments and verify contents', () => {
         argExpr = new CArgumentExpressionElement('myArgExpression', 'TInt');
         expect(argExpr.elementName).toBe('myArgExpression');
-        expect(argExpr.returnType).toBe('TInt');
-        expect(argExpr.type).toBe('expression');
+        expect(argExpr.type).toBe('TInt');
+        expect(argExpr.argType).toBe('expression');
     });
 });
 


### PR DESCRIPTION
- Reorganize code in `structureElements.ts`
- Fix variable naming inconsistencies in `structureElements.d.ts` and `structureElements.ts`
- Document `structureElements.d.ts` and `structureElements.ts`