### PR TITLE
Syntax elements patch and feature addition

### DIFF
--- a/src/.prototype/syntaxElements/programElements/conditionalElements.ts
+++ b/src/.prototype/syntaxElements/programElements/conditionalElements.ts
@@ -1,4 +1,4 @@
-import { BlockElement } from '../structureElements';
+import { ArgumentElement, BlockElement } from '../structureElements';
 
 export namespace ConditionalElement {
     export class IfElseElement extends BlockElement {
@@ -6,6 +6,14 @@ export namespace ConditionalElement {
             super(elementName !== undefined ? elementName : 'if-else', 2, {
                 condition: ['TBoolean']
             });
+        }
+
+        set argCondition(condition: ArgumentElement | null) {
+            this.args.setArg('condition', condition);
+        }
+
+        get argCondition() {
+            return this.args.getArg('condition');
         }
 
         /** @throws Invalid argument */

--- a/src/.prototype/syntaxElements/programElements/dataElements.test.ts
+++ b/src/.prototype/syntaxElements/programElements/dataElements.test.ts
@@ -2,115 +2,273 @@ import { DataElement } from './dataElements';
 import { ValueElement } from './valueElements';
 
 describe('namespace DataElement', () => {
-    test('inititalize IntDataElement with IntElement object and verify', () => {
-        const dataElem = new DataElement.IntDataElement();
-        dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-        dataElem.argValue = new ValueElement.IntElement(5);
-        const arg = dataElem.args.getArg('value');
-        if (arg !== null) {
-            expect(arg.data.value).toBe(5);
-        } else {
-            throw Error('Object should not be null');
-        }
-    });
-
-    test('initialize IntDataElement with ArgumentElement object of unaccepted return-type and expect error', () => {
-        expect(() => {
+    describe('initialization and verification', () => {
+        test('initialize IntDataElement with IntElement object and verify', () => {
             const dataElem = new DataElement.IntDataElement();
             dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-            dataElem.argValue = new ValueElement.TrueElement();
-        }).toThrowError('Invalid argument: "TBoolean" is not a valid type for "value"');
-    });
+            dataElem.argValue = new ValueElement.IntElement(5);
+            const arg = dataElem.args.getArg('value');
+            if (arg !== null) {
+                expect(arg.data.value).toBe(5);
+            } else {
+                throw Error('Object should not be null');
+            }
+        });
 
-    test('inititalize FloatDataElement with FloatElement object and verify', () => {
-        const dataElem = new DataElement.FloatDataElement();
-        dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-        dataElem.argValue = new ValueElement.FloatElement(5.234);
-        const arg = dataElem.args.getArg('value');
-        if (arg !== null) {
-            expect(arg.data.value).toBe(5.234);
-        } else {
-            throw Error('Object should not be null');
-        }
-    });
+        test('initialize IntDataElement with ArgumentElement object of unaccepted return-type and expect error', () => {
+            expect(() => {
+                const dataElem = new DataElement.IntDataElement();
+                dataElem.argIdentifier = new ValueElement.StringElement('myBox');
+                dataElem.argValue = new ValueElement.TrueElement();
+            }).toThrowError('Invalid argument: "TBoolean" is not a valid type for "value"');
+        });
 
-    test('initialize FloatDataElement with ArgumentElement object of unaccepted return-type and expect error', () => {
-        expect(() => {
+        test('initialize FloatDataElement with FloatElement object and verify', () => {
             const dataElem = new DataElement.FloatDataElement();
             dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-            dataElem.argValue = new ValueElement.TrueElement();
-        }).toThrowError('Invalid argument: "TBoolean" is not a valid type for "value"');
-    });
+            dataElem.argValue = new ValueElement.FloatElement(5.234);
+            const arg = dataElem.args.getArg('value');
+            if (arg !== null) {
+                expect(arg.data.value).toBe(5.234);
+            } else {
+                throw Error('Object should not be null');
+            }
+        });
 
-    test('inititalize CharDataElement with CharElement object and verify', () => {
-        const dataElem = new DataElement.CharDataElement();
-        dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-        dataElem.argValue = new ValueElement.CharElement(97);
-        const arg = dataElem.args.getArg('value');
-        if (arg !== null) {
-            expect(arg.data.value).toBe('a');
-        } else {
-            throw Error('Object should not be null');
-        }
-    });
+        test('initialize FloatDataElement with ArgumentElement object of unaccepted return-type and expect error', () => {
+            expect(() => {
+                const dataElem = new DataElement.FloatDataElement();
+                dataElem.argIdentifier = new ValueElement.StringElement('myBox');
+                dataElem.argValue = new ValueElement.TrueElement();
+            }).toThrowError('Invalid argument: "TBoolean" is not a valid type for "value"');
+        });
 
-    test('initialize CharDataElement with ArgumentElement object of unaccepted return-type and expect error', () => {
-        expect(() => {
+        test('initialize CharDataElement with CharElement object and verify', () => {
             const dataElem = new DataElement.CharDataElement();
             dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-            dataElem.argValue = new ValueElement.TrueElement();
-        }).toThrowError('Invalid argument: "TBoolean" is not a valid type for "value"');
-    });
+            dataElem.argValue = new ValueElement.CharElement(97);
+            const arg = dataElem.args.getArg('value');
+            if (arg !== null) {
+                expect(arg.data.value).toBe('a');
+            } else {
+                throw Error('Object should not be null');
+            }
+        });
 
-    test('inititalize StringDataElement with StringElement object and verify', () => {
-        const dataElem = new DataElement.StringDataElement();
-        dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-        dataElem.argValue = new ValueElement.StringElement('string');
-        const arg = dataElem.args.getArg('value');
-        if (arg !== null) {
-            expect(arg.data.value).toBe('string');
-        } else {
-            throw Error('Object should not be null');
-        }
-    });
+        test('initialize CharDataElement with ArgumentElement object of unaccepted return-type and expect error', () => {
+            expect(() => {
+                const dataElem = new DataElement.CharDataElement();
+                dataElem.argIdentifier = new ValueElement.StringElement('myBox');
+                dataElem.argValue = new ValueElement.TrueElement();
+            }).toThrowError('Invalid argument: "TBoolean" is not a valid type for "value"');
+        });
 
-    test('initialize StringDataElement with ArgumentElement object of unaccepted return-type and expect error', () => {
-        expect(() => {
+        test('initialize StringDataElement with StringElement object and verify', () => {
             const dataElem = new DataElement.StringDataElement();
             dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-            dataElem.argValue = new ValueElement.TrueElement();
-        }).toThrowError('Invalid argument: "TBoolean" is not a valid type for "value"');
-    });
+            dataElem.argValue = new ValueElement.StringElement('string');
+            const arg = dataElem.args.getArg('value');
+            if (arg !== null) {
+                expect(arg.data.value).toBe('string');
+            } else {
+                throw Error('Object should not be null');
+            }
+        });
 
-    test('inititalize BooleanDataElement with BooleanElement object and verify', () => {
-        const dataElem = new DataElement.BooleanDataElement();
-        dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-        dataElem.argValue = new ValueElement.TrueElement();
-        const arg = dataElem.args.getArg('value');
-        if (arg !== null) {
-            expect(arg.data.value).toBe(true);
-        } else {
-            throw Error('Object should not be null');
-        }
-    });
+        test('initialize StringDataElement with ArgumentElement object of unaccepted return-type and expect error', () => {
+            expect(() => {
+                const dataElem = new DataElement.StringDataElement();
+                dataElem.argIdentifier = new ValueElement.StringElement('myBox');
+                dataElem.argValue = new ValueElement.TrueElement();
+            }).toThrowError('Invalid argument: "TBoolean" is not a valid type for "value"');
+        });
 
-    test('initialize BooleanDataElement with ArgumentElement object of unaccepted return-type and expect error', () => {
-        expect(() => {
+        test('initialize BooleanDataElement with BooleanElement object and verify', () => {
             const dataElem = new DataElement.BooleanDataElement();
             dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-            dataElem.argValue = new ValueElement.IntElement(5);
-        }).toThrowError('Invalid argument: "TInt" is not a valid type for "value"');
+            dataElem.argValue = new ValueElement.TrueElement();
+            const arg = dataElem.args.getArg('value');
+            if (arg !== null) {
+                expect(arg.data.value).toBe(true);
+            } else {
+                throw Error('Object should not be null');
+            }
+        });
+
+        test('initialize BooleanDataElement with ArgumentElement object of unaccepted return-type and expect error', () => {
+            expect(() => {
+                const dataElem = new DataElement.BooleanDataElement();
+                dataElem.argIdentifier = new ValueElement.StringElement('myBox');
+                dataElem.argValue = new ValueElement.IntElement(5);
+            }).toThrowError('Invalid argument: "TInt" is not a valid type for "value"');
+        });
+
+        test('initialize AnyDataElement with StringElement object and verify', () => {
+            const dataElem = new DataElement.AnyDataElement();
+            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
+            dataElem.argValue = new ValueElement.StringElement('any');
+            const arg = dataElem.args.getArg('value');
+            if (arg !== null) {
+                expect(arg.data.value).toBe('any');
+            } else {
+                throw Error('Object should not be null');
+            }
+        });
     });
 
-    test('inititalize AnyDataElement with StringElement object and verify', () => {
-        const dataElem = new DataElement.AnyDataElement();
-        dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-        dataElem.argValue = new ValueElement.StringElement('any');
-        const arg = dataElem.args.getArg('value');
-        if (arg !== null) {
-            expect(arg.data.value).toBe('any');
-        } else {
-            throw Error('Object should not be null');
-        }
+    describe('value element verification', () => {
+        test('verify created ValueElement after executing a IntDataElement', () => {
+            const dataElem = new DataElement.IntDataElement();
+            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
+            dataElem.argValue = new ValueElement.IntElement(5);
+            dataElem.onVisit();
+            const valueElement = dataElem.valueElement;
+            if (valueElement !== null) {
+                expect(valueElement instanceof ValueElement.IntElement).toBe(true);
+                expect(valueElement.data.value).toBe(5);
+                const dataElement = valueElement.dataElement;
+                expect(dataElement).toEqual(dataElem);
+            } else {
+                throw Error('Object should not be null');
+            }
+        });
+
+        test('attempt to execute a IntDataElement while assigning a null as value and expect error', () => {
+            const dataElem = new DataElement.IntDataElement();
+            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
+            dataElem.argValue = null;
+            expect(() => dataElem.onVisit()).toThrowError('Invalid argument: value cannot be null');
+        });
+
+        test('verify created ValueElement after executing a FloatDataElement', () => {
+            const dataElem = new DataElement.FloatDataElement();
+            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
+            dataElem.argValue = new ValueElement.FloatElement(2.71828);
+            dataElem.onVisit();
+            const valueElement = dataElem.valueElement;
+            if (valueElement !== null) {
+                expect(valueElement instanceof ValueElement.FloatElement).toBe(true);
+                expect(valueElement.data.value).toBe(2.71828);
+                const dataElement = valueElement.dataElement;
+                expect(dataElement).toEqual(dataElem);
+            } else {
+                throw Error('Object should not be null');
+            }
+        });
+
+        test('attempt to execute a FloatDataElement while assigning a null as value and expect error', () => {
+            const dataElem = new DataElement.FloatDataElement();
+            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
+            dataElem.argValue = null;
+            expect(() => dataElem.onVisit()).toThrowError('Invalid argument: value cannot be null');
+        });
+
+        test('verify created ValueElement after executing a CharDataElement', () => {
+            const dataElem = new DataElement.CharDataElement();
+            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
+            dataElem.argValue = new ValueElement.CharElement(97);
+            dataElem.onVisit();
+            const valueElement = dataElem.valueElement;
+            if (valueElement !== null) {
+                expect(valueElement instanceof ValueElement.CharElement).toBe(true);
+                expect(valueElement.data.value).toBe('a');
+                const dataElement = valueElement.dataElement;
+                expect(dataElement).toEqual(dataElem);
+            } else {
+                throw Error('Object should not be null');
+            }
+        });
+
+        test('attempt to execute a CharDataElement while assigning a null as value and expect error', () => {
+            const dataElem = new DataElement.CharDataElement();
+            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
+            dataElem.argValue = null;
+            expect(() => dataElem.onVisit()).toThrowError('Invalid argument: value cannot be null');
+        });
+
+        test('verify created ValueElement after executing a StringDataElement', () => {
+            const dataElem = new DataElement.StringDataElement();
+            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
+            dataElem.argValue = new ValueElement.StringElement('string');
+            dataElem.onVisit();
+            const valueElement = dataElem.valueElement;
+            if (valueElement !== null) {
+                expect(valueElement instanceof ValueElement.StringElement).toBe(true);
+                expect(valueElement.data.value).toBe('string');
+                const dataElement = valueElement.dataElement;
+                expect(dataElement).toEqual(dataElem);
+            } else {
+                throw Error('Object should not be null');
+            }
+        });
+
+        test('attempt to execute a StringDataElement while assigning a null as value and expect error', () => {
+            const dataElem = new DataElement.StringDataElement();
+            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
+            dataElem.argValue = null;
+            expect(() => dataElem.onVisit()).toThrowError('Invalid argument: value cannot be null');
+        });
+
+        test('verify created ValueElement after executing a BooleanDataElement with TrueElement', () => {
+            const dataElem = new DataElement.BooleanDataElement();
+            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
+            dataElem.argValue = new ValueElement.TrueElement();
+            dataElem.onVisit();
+            const valueElement = dataElem.valueElement;
+            if (valueElement !== null) {
+                expect(valueElement instanceof ValueElement.TrueElement).toBe(true);
+                expect(valueElement.data.value).toBe(true);
+                const dataElement = valueElement.dataElement;
+                expect(dataElement).toEqual(dataElem);
+            } else {
+                throw Error('Object should not be null');
+            }
+        });
+
+        test('verify created ValueElement after executing a BooleanDataElement with FalseElement', () => {
+            const dataElem = new DataElement.BooleanDataElement();
+            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
+            dataElem.argValue = new ValueElement.FalseElement();
+            dataElem.onVisit();
+            const valueElement = dataElem.valueElement;
+            if (valueElement !== null) {
+                expect(valueElement instanceof ValueElement.FalseElement).toBe(true);
+                expect(valueElement.data.value).toBe(false);
+                const dataElement = valueElement.dataElement;
+                expect(dataElement).toEqual(dataElem);
+            } else {
+                throw Error('Object should not be null');
+            }
+        });
+
+        test('attempt to execute a BooleanDataElement while assigning a null as value and expect error', () => {
+            const dataElem = new DataElement.BooleanDataElement();
+            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
+            dataElem.argValue = null;
+            expect(() => dataElem.onVisit()).toThrowError('Invalid argument: value cannot be null');
+        });
+
+        test('verify created ValueElement after executing a AnyDataElement', () => {
+            const dataElem = new DataElement.AnyDataElement();
+            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
+            dataElem.argValue = new ValueElement.FalseElement();
+            dataElem.onVisit();
+            const valueElement = dataElem.valueElement;
+            if (valueElement !== null) {
+                expect(valueElement instanceof ValueElement.FalseElement).toBe(true);
+                expect(valueElement.data.value).toBe(false);
+                const dataElement = valueElement.dataElement;
+                expect(dataElement).toEqual(dataElem);
+            } else {
+                throw Error('Object should not be null');
+            }
+        });
+
+        test('attempt to execute a AnyDataElement while assigning a null as value and expect error', () => {
+            const dataElem = new DataElement.AnyDataElement();
+            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
+            dataElem.argValue = null;
+            expect(() => dataElem.onVisit()).toThrowError('Invalid argument: value cannot be null');
+        });
     });
 });

--- a/src/.prototype/syntaxElements/programElements/dataElements.test.ts
+++ b/src/.prototype/syntaxElements/programElements/dataElements.test.ts
@@ -103,172 +103,157 @@ describe('namespace DataElement', () => {
             }).toThrowError('Invalid argument: "TInt" is not a valid type for "value"');
         });
 
-        test('initialize AnyDataElement with StringElement object and verify', () => {
-            const dataElem = new DataElement.AnyDataElement();
-            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-            dataElem.argValue = new ValueElement.StringElement('any');
-            const arg = dataElem.args.getArg('value');
-            if (arg !== null) {
-                expect(arg.data.value).toBe('any');
-            } else {
-                throw Error('Object should not be null');
-            }
-        });
+        // test('initialize AnyDataElement with StringElement object and verify', () => {
+        //     const dataElem = new DataElement.AnyDataElement();
+        //     dataElem.argIdentifier = new ValueElement.StringElement('myBox');
+        //     dataElem.argValue = new ValueElement.StringElement('any');
+        //     const arg = dataElem.args.getArg('value');
+        //     if (arg !== null) {
+        //         expect(arg.data.value).toBe('any');
+        //     } else {
+        //         throw Error('Object should not be null');
+        //     }
+        // });
     });
 
     describe('value element verification', () => {
-        test('verify created ValueElement after executing a IntDataElement', () => {
+        test('verify reference in created DataValueElement after assigning a IntDataElement', () => {
             const dataElem = new DataElement.IntDataElement();
             dataElem.argIdentifier = new ValueElement.StringElement('myBox');
             dataElem.argValue = new ValueElement.IntElement(5);
-            dataElem.onVisit();
             const valueElement = dataElem.valueElement;
-            if (valueElement !== null) {
-                expect(valueElement instanceof ValueElement.IntElement).toBe(true);
-                expect(valueElement.data.value).toBe(5);
-                const dataElement = valueElement.dataElement;
-                expect(dataElement).toEqual(dataElem);
-            } else {
-                throw Error('Object should not be null');
-            }
+            expect(valueElement instanceof ValueElement.IntDataValueElement).toBe(true);
+            expect(valueElement.data.value).toBe(5);
+            const dataElement = valueElement.data;
+            expect(dataElement).toEqual(dataElem.dataElementRef);
         });
 
-        test('attempt to execute a IntDataElement while assigning a null as value and expect error', () => {
+        test('attempt to fetch TInt reference while assigning a null as value and expect error', () => {
             const dataElem = new DataElement.IntDataElement();
             dataElem.argIdentifier = new ValueElement.StringElement('myBox');
             dataElem.argValue = null;
-            expect(() => dataElem.onVisit()).toThrowError('Invalid argument: value cannot be null');
+            expect(() => dataElem.dataElementRef).toThrowError(
+                'Invalid argument: value cannot be null'
+            );
         });
 
-        test('verify created ValueElement after executing a FloatDataElement', () => {
+        test('verify reference in created DataValueElement after assigning a FloatDataElement', () => {
             const dataElem = new DataElement.FloatDataElement();
             dataElem.argIdentifier = new ValueElement.StringElement('myBox');
             dataElem.argValue = new ValueElement.FloatElement(2.71828);
             dataElem.onVisit();
             const valueElement = dataElem.valueElement;
-            if (valueElement !== null) {
-                expect(valueElement instanceof ValueElement.FloatElement).toBe(true);
-                expect(valueElement.data.value).toBe(2.71828);
-                const dataElement = valueElement.dataElement;
-                expect(dataElement).toEqual(dataElem);
-            } else {
-                throw Error('Object should not be null');
-            }
+            expect(valueElement instanceof ValueElement.FloatDataValueElement).toBe(true);
+            expect(valueElement.data.value).toBe(2.71828);
+            const dataElement = valueElement.data;
+            expect(dataElement).toEqual(dataElem.dataElementRef);
         });
 
-        test('attempt to execute a FloatDataElement while assigning a null as value and expect error', () => {
+        test('attempt to fetch TFloat reference while assigning a null as value and expect error', () => {
             const dataElem = new DataElement.FloatDataElement();
             dataElem.argIdentifier = new ValueElement.StringElement('myBox');
             dataElem.argValue = null;
-            expect(() => dataElem.onVisit()).toThrowError('Invalid argument: value cannot be null');
+            expect(() => dataElem.dataElementRef).toThrowError(
+                'Invalid argument: value cannot be null'
+            );
         });
 
-        test('verify created ValueElement after executing a CharDataElement', () => {
+        test('verify reference in created DataValueElement after assigning a CharDataElement', () => {
             const dataElem = new DataElement.CharDataElement();
             dataElem.argIdentifier = new ValueElement.StringElement('myBox');
             dataElem.argValue = new ValueElement.CharElement(97);
             dataElem.onVisit();
             const valueElement = dataElem.valueElement;
-            if (valueElement !== null) {
-                expect(valueElement instanceof ValueElement.CharElement).toBe(true);
-                expect(valueElement.data.value).toBe('a');
-                const dataElement = valueElement.dataElement;
-                expect(dataElement).toEqual(dataElem);
-            } else {
-                throw Error('Object should not be null');
-            }
+            expect(valueElement instanceof ValueElement.CharDataValueElement).toBe(true);
+            expect(valueElement.data.value).toBe('a');
+            const dataElement = valueElement.data;
+            expect(dataElement).toEqual(dataElem.dataElementRef);
         });
 
-        test('attempt to execute a CharDataElement while assigning a null as value and expect error', () => {
+        test('attempt to fetch TChar reference while assigning a null as value and expect error', () => {
             const dataElem = new DataElement.CharDataElement();
             dataElem.argIdentifier = new ValueElement.StringElement('myBox');
             dataElem.argValue = null;
-            expect(() => dataElem.onVisit()).toThrowError('Invalid argument: value cannot be null');
+            expect(() => dataElem.dataElementRef).toThrowError(
+                'Invalid argument: value cannot be null'
+            );
         });
 
-        test('verify created ValueElement after executing a StringDataElement', () => {
+        test('verify reference in created DataValueElement after assigning a StringDataElement', () => {
             const dataElem = new DataElement.StringDataElement();
             dataElem.argIdentifier = new ValueElement.StringElement('myBox');
             dataElem.argValue = new ValueElement.StringElement('string');
             dataElem.onVisit();
             const valueElement = dataElem.valueElement;
-            if (valueElement !== null) {
-                expect(valueElement instanceof ValueElement.StringElement).toBe(true);
-                expect(valueElement.data.value).toBe('string');
-                const dataElement = valueElement.dataElement;
-                expect(dataElement).toEqual(dataElem);
-            } else {
-                throw Error('Object should not be null');
-            }
+            expect(valueElement instanceof ValueElement.StringDataValueElement).toBe(true);
+            expect(valueElement.data.value).toBe('string');
+            const dataElement = valueElement.data;
+            expect(dataElement).toEqual(dataElem.dataElementRef);
         });
 
-        test('attempt to execute a StringDataElement while assigning a null as value and expect error', () => {
+        test('attempt to fetch TString reference while assigning a null as value and expect error', () => {
             const dataElem = new DataElement.StringDataElement();
             dataElem.argIdentifier = new ValueElement.StringElement('myBox');
             dataElem.argValue = null;
-            expect(() => dataElem.onVisit()).toThrowError('Invalid argument: value cannot be null');
+            expect(() => dataElem.dataElementRef).toThrowError(
+                'Invalid argument: value cannot be null'
+            );
         });
 
-        test('verify created ValueElement after executing a BooleanDataElement with TrueElement', () => {
+        test('verify reference in created DataValueElement after assigning a BooleanDataElement with TrueElement', () => {
             const dataElem = new DataElement.BooleanDataElement();
             dataElem.argIdentifier = new ValueElement.StringElement('myBox');
             dataElem.argValue = new ValueElement.TrueElement();
             dataElem.onVisit();
             const valueElement = dataElem.valueElement;
-            if (valueElement !== null) {
-                expect(valueElement instanceof ValueElement.TrueElement).toBe(true);
-                expect(valueElement.data.value).toBe(true);
-                const dataElement = valueElement.dataElement;
-                expect(dataElement).toEqual(dataElem);
-            } else {
-                throw Error('Object should not be null');
-            }
+            expect(valueElement instanceof ValueElement.BooleanDataValueElement).toBe(true);
+            expect(valueElement.data.value).toBe(true);
+            const dataElement = valueElement.data;
+            expect(dataElement).toEqual(dataElem.dataElementRef);
         });
 
-        test('verify created ValueElement after executing a BooleanDataElement with FalseElement', () => {
+        test('verify reference in created DataValueElement after assigning a BooleanDataElement with FalseElement', () => {
             const dataElem = new DataElement.BooleanDataElement();
             dataElem.argIdentifier = new ValueElement.StringElement('myBox');
             dataElem.argValue = new ValueElement.FalseElement();
             dataElem.onVisit();
             const valueElement = dataElem.valueElement;
-            if (valueElement !== null) {
-                expect(valueElement instanceof ValueElement.FalseElement).toBe(true);
-                expect(valueElement.data.value).toBe(false);
-                const dataElement = valueElement.dataElement;
-                expect(dataElement).toEqual(dataElem);
-            } else {
-                throw Error('Object should not be null');
-            }
+            expect(valueElement instanceof ValueElement.BooleanDataValueElement).toBe(true);
+            expect(valueElement.data.value).toBe(false);
+            const dataElement = valueElement.data;
+            expect(dataElement).toEqual(dataElem.dataElementRef);
         });
 
-        test('attempt to execute a BooleanDataElement while assigning a null as value and expect error', () => {
+        test('attempt to fetch TBoolean reference while assigning a null as value and expect error', () => {
             const dataElem = new DataElement.BooleanDataElement();
             dataElem.argIdentifier = new ValueElement.StringElement('myBox');
             dataElem.argValue = null;
-            expect(() => dataElem.onVisit()).toThrowError('Invalid argument: value cannot be null');
+            expect(() => dataElem.dataElementRef).toThrowError(
+                'Invalid argument: value cannot be null'
+            );
         });
 
-        test('verify created ValueElement after executing a AnyDataElement', () => {
-            const dataElem = new DataElement.AnyDataElement();
-            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-            dataElem.argValue = new ValueElement.FalseElement();
-            dataElem.onVisit();
-            const valueElement = dataElem.valueElement;
-            if (valueElement !== null) {
-                expect(valueElement instanceof ValueElement.FalseElement).toBe(true);
-                expect(valueElement.data.value).toBe(false);
-                const dataElement = valueElement.dataElement;
-                expect(dataElement).toEqual(dataElem);
-            } else {
-                throw Error('Object should not be null');
-            }
-        });
+        // test('verify created ValueElement after executing a AnyDataElement', () => {
+        //     const dataElem = new DataElement.AnyDataElement();
+        //     dataElem.argIdentifier = new ValueElement.StringElement('myBox');
+        //     dataElem.argValue = new ValueElement.FalseElement();
+        //     dataElem.onVisit();
+        //     const valueElement = dataElem.valueElement;
+        //     if (valueElement !== null) {
+        //         expect(valueElement instanceof ValueElement.FalseElement).toBe(true);
+        //         expect(valueElement.data.value).toBe(false);
+        //         const dataElement = valueElement.dataElement;
+        //         expect(dataElement).toEqual(dataElem);
+        //     } else {
+        //         throw Error('Object should not be null');
+        //     }
+        // });
 
-        test('attempt to execute a AnyDataElement while assigning a null as value and expect error', () => {
-            const dataElem = new DataElement.AnyDataElement();
-            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-            dataElem.argValue = null;
-            expect(() => dataElem.onVisit()).toThrowError('Invalid argument: value cannot be null');
-        });
+        // test('attempt to execute a AnyDataElement while assigning a null as value and expect error', () => {
+        //     const dataElem = new DataElement.AnyDataElement();
+        //     dataElem.argIdentifier = new ValueElement.StringElement('myBox');
+        //     dataElem.argValue = null;
+        //     expect(() => dataElem.onVisit()).toThrowError('Invalid argument: value cannot be null');
+        // });
     });
 });

--- a/src/.prototype/syntaxElements/programElements/dataElements.ts
+++ b/src/.prototype/syntaxElements/programElements/dataElements.ts
@@ -1,4 +1,4 @@
-import { TPrimitiveName } from '../@types/primitiveTypes';
+import { TPrimitive, TPrimitiveName } from '../@types/primitiveTypes';
 import { TBoolean, TChar, TFloat, TInt, TString } from '../primitiveElements';
 import { ArgumentElement, StatementElement } from '../structureElements';
 import { ValueElement } from './valueElements';
@@ -13,11 +13,18 @@ type dataValueType =
 
 export namespace DataElement {
     abstract class DataElement extends StatementElement {
-        constructor(identifier: string, valueConstraints: TPrimitiveName[]) {
+        private _type: TPrimitiveName;
+
+        constructor(identifier: string, type: TPrimitiveName) {
             super(identifier, {
                 identifier: ['TString'],
-                value: valueConstraints
+                value: [type]
             });
+            this._type = type;
+        }
+
+        get type() {
+            return this._type;
         }
 
         /** @throws Invalid argument */
@@ -38,22 +45,28 @@ export namespace DataElement {
             return this.args.getArg('value');
         }
 
-        abstract get valueElement(): dataValueType | null;
+        abstract get valueElement(): dataValueType;
+
+        abstract get dataElementRef(): TPrimitive;
 
         abstract onVisit(): void;
     }
 
     export class IntDataElement extends DataElement {
         constructor() {
-            super('data-int', ['TInt']);
+            super('data-int', 'TInt');
         }
 
         get valueElement() {
+            return new ValueElement.IntDataValueElement(this);
+        }
+
+        get dataElementRef() {
             const arg = this.argValue;
             if (arg === null) {
                 throw Error('Invalid argument: value cannot be null');
             } else {
-                return new ValueElement.IntDataValueElement(arg.data as TInt);
+                return arg.data as TInt;
             }
         }
 
@@ -62,15 +75,19 @@ export namespace DataElement {
 
     export class FloatDataElement extends DataElement {
         constructor() {
-            super('data-float', ['TFloat']);
+            super('data-float', 'TFloat');
         }
 
         get valueElement() {
+            return new ValueElement.FloatDataValueElement(this);
+        }
+
+        get dataElementRef() {
             const arg = this.argValue;
             if (arg === null) {
                 throw Error('Invalid argument: value cannot be null');
             } else {
-                return new ValueElement.FloatDataValueElement(arg.data as TFloat);
+                return arg.data as TFloat;
             }
         }
 
@@ -79,15 +96,19 @@ export namespace DataElement {
 
     export class CharDataElement extends DataElement {
         constructor() {
-            super('data-char', ['TChar']);
+            super('data-char', 'TChar');
         }
 
         get valueElement() {
+            return new ValueElement.CharDataValueElement(this);
+        }
+
+        get dataElementRef() {
             const arg = this.argValue;
             if (arg === null) {
                 throw Error('Invalid argument: value cannot be null');
             } else {
-                return new ValueElement.CharDataValueElement(arg.data as TChar);
+                return arg.data as TChar;
             }
         }
 
@@ -96,15 +117,19 @@ export namespace DataElement {
 
     export class StringDataElement extends DataElement {
         constructor() {
-            super('data-string', ['TString']);
+            super('data-string', 'TString');
         }
 
         get valueElement() {
+            return new ValueElement.StringDataValueElement(this);
+        }
+
+        get dataElementRef() {
             const arg = this.argValue;
             if (arg === null) {
                 throw Error('Invalid argument: value cannot be null');
             } else {
-                return new ValueElement.StringDataValueElement(arg.data as TString);
+                return arg.data as TString;
             }
         }
 
@@ -113,48 +138,56 @@ export namespace DataElement {
 
     export class BooleanDataElement extends DataElement {
         constructor() {
-            super('data-boolean', ['TBoolean']);
+            super('data-boolean', 'TBoolean');
         }
 
         get valueElement() {
+            return new ValueElement.BooleanDataValueElement(this);
+        }
+
+        get dataElementRef() {
             const arg = this.argValue;
             if (arg === null) {
                 throw Error('Invalid argument: value cannot be null');
             } else {
-                return new ValueElement.BooleanDataValueElement(arg.data as TBoolean);
+                return arg.data as TBoolean;
             }
         }
 
         onVisit() {}
     }
 
-    export class AnyDataElement extends DataElement {
-        constructor() {
-            super('data-any', ['TInt', 'TFloat', 'TChar', 'TString', 'TBoolean']);
-        }
+    // export class AnyDataElement extends DataElement {
+    //     constructor() {
+    //         super('data-any', ['TInt', 'TFloat', 'TChar', 'TString', 'TBoolean']);
+    //     }
 
-        get valueElement() {
-            const argValue = this.argValue;
-            if (argValue === null) {
-                throw Error('Invalid argument: value cannot be null');
-            } else {
-                const arg = argValue.data;
-                if (arg instanceof TInt) {
-                    return new ValueElement.IntDataValueElement(arg as TInt);
-                } else if (arg instanceof TFloat) {
-                    return new ValueElement.FloatDataValueElement(arg as TFloat);
-                } else if (arg instanceof TChar) {
-                    return new ValueElement.CharDataValueElement(arg as TChar);
-                } else if (arg instanceof TString) {
-                    return new ValueElement.StringDataValueElement(arg as TString);
-                } else {
-                    return new ValueElement.BooleanDataValueElement(arg as TBoolean);
-                }
-            }
-        }
+    //     get valueElement() {
+    //         return new ValueElement.IntDataValueElement(this);
+    //     }
 
-        onVisit() {}
-    }
+    //     get dataElementRef() {
+    //         const argValue = this.argValue;
+    //         if (argValue === null) {
+    //             throw Error('Invalid argument: value cannot be null');
+    //         } else {
+    //             const arg = argValue.data;
+    //             if (arg instanceof TInt) {
+    //                 return arg as TInt;
+    //             } else if (arg instanceof TFloat) {
+    //                 return arg as TFloat;
+    //             } else if (arg instanceof TChar) {
+    //                 return arg as TChar;
+    //             } else if (arg instanceof TString) {
+    //                 return arg as TString;
+    //             } else {
+    //                 return arg as TBoolean;
+    //             }
+    //         }
+    //     }
+
+    //     onVisit() {}
+    // }
 
     abstract class UpdateDataElement extends StatementElement {
         constructor(

--- a/src/.prototype/syntaxElements/programElements/dataElements.ts
+++ b/src/.prototype/syntaxElements/programElements/dataElements.ts
@@ -208,12 +208,12 @@ export namespace DataElement {
             return this.args.getArg('currValue') as dataValueType;
         }
 
-        set argNewValue(value: dataValueType | null) {
+        set argNewValue(value: ArgumentElement | null) {
             this.args.setArg('newValue', value);
         }
 
         get argNewValue() {
-            return this.args.getArg('newValue') as dataValueType;
+            return this.args.getArg('newValue');
         }
 
         onVisit() {

--- a/src/.prototype/syntaxElements/programElements/dataElements.ts
+++ b/src/.prototype/syntaxElements/programElements/dataElements.ts
@@ -1,10 +1,21 @@
 import { TPrimitiveName } from '../@types/primitiveTypes';
+import { TChar, TFloat, TInt, TString } from '../primitiveElements';
 import { ArgumentElement, StatementElement } from '../structureElements';
+import { ValueElement } from './valueElements';
 
 type argType = ArgumentElement | null;
+type valueType =
+    | ValueElement.IntElement
+    | ValueElement.FloatElement
+    | ValueElement.CharElement
+    | ValueElement.StringElement
+    | ValueElement.TrueElement
+    | ValueElement.FalseElement;
 
 export namespace DataElement {
-    class DataElement extends StatementElement {
+    abstract class DataElement extends StatementElement {
+        protected _valueElement: valueType | null = null;
+
         constructor(identifier: string, valueConstraints: TPrimitiveName[]) {
             super(identifier, {
                 identifier: ['TString'],
@@ -30,13 +41,26 @@ export namespace DataElement {
             return this.args.getArg('value');
         }
 
-        /** @todo: Implement this after creating Synbol Table. */
-        onVisit() {}
+        get valueElement() {
+            return this._valueElement;
+        }
+
+        abstract onVisit(): void;
     }
 
     export class IntDataElement extends DataElement {
         constructor() {
             super('data-int', ['TInt']);
+        }
+
+        onVisit() {
+            const arg = this.argValue;
+            if (arg === null) {
+                throw Error('Invalid argument: value cannot be null');
+            } else {
+                this._valueElement = new ValueElement.IntElement((arg.data as TInt).value);
+                this._valueElement.dataElement = this;
+            }
         }
     }
 
@@ -44,11 +68,31 @@ export namespace DataElement {
         constructor() {
             super('data-float', ['TFloat']);
         }
+
+        onVisit() {
+            const arg = this.argValue;
+            if (arg === null) {
+                throw Error('Invalid argument: value cannot be null');
+            } else {
+                this._valueElement = new ValueElement.FloatElement((arg.data as TFloat).value);
+                this._valueElement.dataElement = this;
+            }
+        }
     }
 
     export class CharDataElement extends DataElement {
         constructor() {
             super('data-char', ['TChar']);
+        }
+
+        onVisit() {
+            const arg = this.argValue;
+            if (arg === null) {
+                throw Error('Invalid argument: value cannot be null');
+            } else {
+                this._valueElement = new ValueElement.CharElement((arg.data as TChar).value);
+                this._valueElement.dataElement = this;
+            }
         }
     }
 
@@ -56,17 +100,62 @@ export namespace DataElement {
         constructor() {
             super('data-string', ['TString']);
         }
+
+        onVisit() {
+            const arg = this.argValue;
+            if (arg === null) {
+                throw Error('Invalid argument: value cannot be null');
+            } else {
+                this._valueElement = new ValueElement.StringElement((arg.data as TString).value);
+                this._valueElement.dataElement = this;
+            }
+        }
     }
 
     export class BooleanDataElement extends DataElement {
         constructor() {
             super('data-boolean', ['TBoolean']);
         }
+
+        onVisit() {
+            const arg = this.argValue;
+            if (arg === null) {
+                throw Error('Invalid argument: value cannot be null');
+            } else {
+                this._valueElement = arg.data.value
+                    ? new ValueElement.TrueElement()
+                    : new ValueElement.FalseElement();
+                this._valueElement.dataElement = this;
+            }
+        }
     }
 
     export class AnyDataElement extends DataElement {
         constructor() {
             super('data-any', ['TInt', 'TFloat', 'TChar', 'TString', 'TBoolean']);
+        }
+
+        onVisit() {
+            const argValue = this.argValue;
+            if (argValue === null) {
+                throw Error('Invalid argument: value cannot be null');
+            } else {
+                const arg = argValue.data;
+                if (arg instanceof TInt) {
+                    this._valueElement = new ValueElement.IntElement(arg.value);
+                } else if (arg instanceof TFloat) {
+                    this._valueElement = new ValueElement.FloatElement(arg.value);
+                } else if (arg instanceof TChar) {
+                    this._valueElement = new ValueElement.CharElement(arg.value);
+                } else if (arg instanceof TString) {
+                    this._valueElement = new ValueElement.StringElement(arg.value);
+                } else {
+                    this._valueElement = arg.value
+                        ? new ValueElement.TrueElement()
+                        : new ValueElement.FalseElement();
+                }
+                this._valueElement.dataElement = this;
+            }
         }
     }
 }

--- a/src/.prototype/syntaxElements/programElements/loopElements.test.ts
+++ b/src/.prototype/syntaxElements/programElements/loopElements.test.ts
@@ -23,11 +23,5 @@ describe('namespace LoopElement', () => {
                 'Invalid argument: Repeat loop needs a positive value'
             );
         });
-
-        test('Attempt to assign a negative value to repeat and expect error', () => {
-            expect(() => (repeatElem.argValue = new ValueElement.IntElement(-5))).toThrowError(
-                'Invalid argument: Repeat loop needs a positive value'
-            );
-        });
     });
 });

--- a/src/.prototype/syntaxElements/programElements/loopElements.ts
+++ b/src/.prototype/syntaxElements/programElements/loopElements.ts
@@ -1,24 +1,20 @@
-import { TInt } from '../primitiveElements';
+import { TFloat, TInt } from '../primitiveElements';
 import { ArgumentElement, BlockElement, InstructionElement } from '../structureElements';
 
 export namespace LoopElement {
     export class RepeatLoopElement extends BlockElement {
-        private _nextStore: InstructionElement | null;
+        private _nextStore: InstructionElement | null = null;
         private _counter: number = 0;
 
         constructor() {
             super('repeat', 1, {
-                value: ['TInt']
+                value: ['TInt', 'TFloat']
             });
-            this._nextStore = this.next;
         }
 
         set argValue(value: ArgumentElement | null) {
             if (value !== null) {
-                const data = value.data as TInt;
-                if (data.value < 0) {
-                    throw Error('Invalid argument: Repeat loop needs a positive value');
-                }
+                const data = TInt.TInt(value.data as TInt | TFloat);
                 this._counter = data.value;
             } else {
                 this._counter = 0;
@@ -28,9 +24,13 @@ export namespace LoopElement {
 
         onVisit() {
             const arg = this.args.getArg('value');
-            if (arg === null) {
+            if (arg === null || arg.data.value < 0) {
                 throw Error('Invalid argument: Repeat loop needs a positive value');
             }
+            if (this._nextStore === null) {
+                this._nextStore = this.next;
+            }
+            this.childHead = this.getChildHead(0);
         }
 
         onExit() {
@@ -39,6 +39,7 @@ export namespace LoopElement {
                 this.next = this;
             } else {
                 this.next = this._nextStore;
+                this._nextStore = null;
             }
         }
     }

--- a/src/.prototype/syntaxElements/programElements/miscellaneousElements.ts
+++ b/src/.prototype/syntaxElements/programElements/miscellaneousElements.ts
@@ -1,0 +1,25 @@
+import { ArgumentElement, StatementElement } from '../structureElements';
+
+export namespace MiscellaneousElement {
+    export class PrintElement extends StatementElement {
+        constructor() {
+            super('print', {
+                message: ['TInt', 'TFloat', 'TChar', 'TString', 'TBoolean']
+            });
+        }
+
+        set argMessage(message: ArgumentElement | null) {
+            this.args.setArg('message', message);
+        }
+
+        /** @todo logic to be implemented after UI is created. Currently just for demonstration. */
+        onVisit() {
+            const arg = this.args.getArg('message');
+            if (arg !== null) {
+                console.log(`" ${arg.data.value} "`);
+            } else {
+                console.log(`" ${null} "`);
+            }
+        }
+    }
+}

--- a/src/.prototype/syntaxElements/programElements/valueElements.ts
+++ b/src/.prototype/syntaxElements/programElements/valueElements.ts
@@ -1,12 +1,38 @@
+import { TPrimitive } from '../@types/primitiveTypes';
 import { TInt, TFloat, TChar, TString, TBoolean } from '../primitiveElements';
 import { ArgumentDataElement } from '../structureElements';
+import { DataElement } from './dataElements';
+
+type dataElemType =
+    | DataElement.IntDataElement
+    | DataElement.FloatDataElement
+    | DataElement.CharDataElement
+    | DataElement.StringDataElement
+    | DataElement.BooleanDataElement
+    | DataElement.AnyDataElement;
 
 /**
  * @abstract All ValueElements are ArgumentDataElements.
  */
 export namespace ValueElement {
+    abstract class ValueElement extends ArgumentDataElement {
+        private _dataElem: dataElemType | null = null;
+
+        constructor(elementName: string, data: TPrimitive) {
+            super(elementName, data);
+        }
+
+        set dataElement(dataElement: dataElemType | null) {
+            this._dataElem = dataElement;
+        }
+
+        get dataElement() {
+            return this._dataElem;
+        }
+    }
+
     /** ArgumentDataElement wrapper for primitive TInt type. */
-    export class IntElement extends ArgumentDataElement {
+    export class IntElement extends ValueElement {
         constructor(value: number) {
             super('int', new TInt(value));
         }
@@ -17,7 +43,7 @@ export namespace ValueElement {
     }
 
     /** ArgumentDataElement wrapper for primitive TFloat type. */
-    export class FloatElement extends ArgumentDataElement {
+    export class FloatElement extends ValueElement {
         constructor(value: number) {
             super('float', new TFloat(value));
         }
@@ -28,7 +54,7 @@ export namespace ValueElement {
     }
 
     /** ArgumentDataElement wrapper for primitive TChar type. */
-    export class CharElement extends ArgumentDataElement {
+    export class CharElement extends ValueElement {
         constructor(value: string | number) {
             super('char', new TChar(value));
         }
@@ -39,7 +65,7 @@ export namespace ValueElement {
     }
 
     /** ArgumentDataElement wrapper for primitive TString type. */
-    export class StringElement extends ArgumentDataElement {
+    export class StringElement extends ValueElement {
         constructor(value: string) {
             super('string', new TString(value));
         }
@@ -50,14 +76,14 @@ export namespace ValueElement {
     }
 
     /** ArgumentDataElement wrapper for primitive TBoolean(true) type. */
-    export class TrueElement extends ArgumentDataElement {
+    export class TrueElement extends ValueElement {
         constructor() {
             super('true', new TBoolean(true));
         }
     }
 
     /** ArgumentDataElement wrapper for primitive TBoolean(false) type. */
-    export class FalseElement extends ArgumentDataElement {
+    export class FalseElement extends ValueElement {
         constructor() {
             super('false', new TBoolean(false));
         }

--- a/src/.prototype/syntaxElements/programElements/valueElements.ts
+++ b/src/.prototype/syntaxElements/programElements/valueElements.ts
@@ -1,14 +1,30 @@
 import { TPrimitive } from '../@types/primitiveTypes';
 import { TInt, TFloat, TChar, TString, TBoolean } from '../primitiveElements';
 import { ArgumentDataElement } from '../structureElements';
+import { DataElement } from './dataElements';
+
+type dataElemType =
+    | DataElement.IntDataElement
+    | DataElement.FloatDataElement
+    | DataElement.CharDataElement
+    | DataElement.StringDataElement
+    | DataElement.BooleanDataElement;
+// | DataElement.AnyDataElement;
 
 /**
  * @abstract All ValueElements are ArgumentDataElements.
  */
 export namespace ValueElement {
     abstract class ValueElement extends ArgumentDataElement {
+        private _data: TPrimitive;
+
         constructor(elementName: string, data: TPrimitive) {
-            super(elementName, data);
+            super(elementName, data.type);
+            this._data = data;
+        }
+
+        get data() {
+            return this._data;
         }
     }
 
@@ -23,13 +39,6 @@ export namespace ValueElement {
         }
     }
 
-    /** Maybe merged into IntElement. */
-    export class IntDataValueElement extends ValueElement {
-        constructor(data: TInt) {
-            super('data-value-int', data);
-        }
-    }
-
     /** ArgumentDataElement wrapper for primitive TFloat type. */
     export class FloatElement extends ValueElement {
         constructor(value: number) {
@@ -38,13 +47,6 @@ export namespace ValueElement {
 
         update(value: number) {
             this.data.value = value;
-        }
-    }
-
-    /** Maybe merged into FloatElement. */
-    export class FloatDataValueElement extends ValueElement {
-        constructor(data: TFloat) {
-            super('data-value-float', data);
         }
     }
 
@@ -59,13 +61,6 @@ export namespace ValueElement {
         }
     }
 
-    /** Maybe merged into CharElement. */
-    export class CharDataValueElement extends ValueElement {
-        constructor(data: TChar) {
-            super('data-value-char', data);
-        }
-    }
-
     /** ArgumentDataElement wrapper for primitive TString type. */
     export class StringElement extends ValueElement {
         constructor(value: string) {
@@ -74,13 +69,6 @@ export namespace ValueElement {
 
         update(value: string) {
             this.data.value = value;
-        }
-    }
-
-    /** Maybe merged into StringElement. */
-    export class StringDataValueElement extends ValueElement {
-        constructor(data: TString) {
-            super('data-value-string', data);
         }
     }
 
@@ -98,9 +86,47 @@ export namespace ValueElement {
         }
     }
 
-    export class BooleanDataValueElement extends ValueElement {
-        constructor(data: TBoolean) {
-            super('data-value-boolean', data);
+    abstract class DataValueElement extends ArgumentDataElement {
+        private _dataElementRef: dataElemType;
+
+        constructor(elementName: string, dataElement: dataElemType) {
+            super(elementName, dataElement.type);
+            this._dataElementRef = dataElement;
+        }
+
+        /** @override */
+        get data() {
+            return this._dataElementRef.dataElementRef;
+        }
+    }
+
+    export class IntDataValueElement extends DataValueElement {
+        constructor(dataElement: DataElement.IntDataElement) {
+            super('data-value-int', dataElement);
+        }
+    }
+
+    export class FloatDataValueElement extends DataValueElement {
+        constructor(dataElement: DataElement.FloatDataElement) {
+            super('data-value-float', dataElement);
+        }
+    }
+
+    export class CharDataValueElement extends DataValueElement {
+        constructor(dataElement: DataElement.CharDataElement) {
+            super('data-value-char', dataElement);
+        }
+    }
+
+    export class StringDataValueElement extends DataValueElement {
+        constructor(dataElement: DataElement.StringDataElement) {
+            super('data-value-string', dataElement);
+        }
+    }
+
+    export class BooleanDataValueElement extends DataValueElement {
+        constructor(dataElement: DataElement.BooleanDataElement) {
+            super('data-value-boolean', dataElement);
         }
     }
 }

--- a/src/.prototype/syntaxElements/programElements/valueElements.ts
+++ b/src/.prototype/syntaxElements/programElements/valueElements.ts
@@ -1,33 +1,14 @@
 import { TPrimitive } from '../@types/primitiveTypes';
 import { TInt, TFloat, TChar, TString, TBoolean } from '../primitiveElements';
 import { ArgumentDataElement } from '../structureElements';
-import { DataElement } from './dataElements';
-
-type dataElemType =
-    | DataElement.IntDataElement
-    | DataElement.FloatDataElement
-    | DataElement.CharDataElement
-    | DataElement.StringDataElement
-    | DataElement.BooleanDataElement
-    | DataElement.AnyDataElement;
 
 /**
  * @abstract All ValueElements are ArgumentDataElements.
  */
 export namespace ValueElement {
     abstract class ValueElement extends ArgumentDataElement {
-        private _dataElem: dataElemType | null = null;
-
         constructor(elementName: string, data: TPrimitive) {
             super(elementName, data);
-        }
-
-        set dataElement(dataElement: dataElemType | null) {
-            this._dataElem = dataElement;
-        }
-
-        get dataElement() {
-            return this._dataElem;
         }
     }
 
@@ -42,6 +23,13 @@ export namespace ValueElement {
         }
     }
 
+    /** Maybe merged into IntElement. */
+    export class IntDataValueElement extends ValueElement {
+        constructor(data: TInt) {
+            super('data-value-int', data);
+        }
+    }
+
     /** ArgumentDataElement wrapper for primitive TFloat type. */
     export class FloatElement extends ValueElement {
         constructor(value: number) {
@@ -50,6 +38,13 @@ export namespace ValueElement {
 
         update(value: number) {
             this.data.value = value;
+        }
+    }
+
+    /** Maybe merged into FloatElement. */
+    export class FloatDataValueElement extends ValueElement {
+        constructor(data: TFloat) {
+            super('data-value-float', data);
         }
     }
 
@@ -64,6 +59,13 @@ export namespace ValueElement {
         }
     }
 
+    /** Maybe merged into CharElement. */
+    export class CharDataValueElement extends ValueElement {
+        constructor(data: TChar) {
+            super('data-value-char', data);
+        }
+    }
+
     /** ArgumentDataElement wrapper for primitive TString type. */
     export class StringElement extends ValueElement {
         constructor(value: string) {
@@ -72,6 +74,13 @@ export namespace ValueElement {
 
         update(value: string) {
             this.data.value = value;
+        }
+    }
+
+    /** Maybe merged into StringElement. */
+    export class StringDataValueElement extends ValueElement {
+        constructor(data: TString) {
+            super('data-value-string', data);
         }
     }
 
@@ -86,6 +95,12 @@ export namespace ValueElement {
     export class FalseElement extends ValueElement {
         constructor() {
             super('false', new TBoolean(false));
+        }
+    }
+
+    export class BooleanDataValueElement extends ValueElement {
+        constructor(data: TBoolean) {
+            super('data-value-boolean', data);
         }
     }
 }

--- a/src/.prototype/syntaxElements/structureElements.test.ts
+++ b/src/.prototype/syntaxElements/structureElements.test.ts
@@ -7,7 +7,11 @@ import {
 } from './structureElements';
 
 /** Dummy class to extend abstract class ArgumentDataElement. */
-class CArgumentDataElement extends ArgumentDataElement {}
+class CArgumentDataElement extends ArgumentDataElement {
+    get data() {
+        return new TInt(5);
+    }
+}
 /** Dummy class to extend abstract class ArgumentExpressionElement. */
 class CArgumentExpressionElement extends ArgumentExpressionElement {
     get data() {
@@ -24,56 +28,26 @@ class CBlockElement extends BlockElement {
     onExit() {}
 }
 
-let argData_int: ArgumentDataElement;
-let argData_float: ArgumentDataElement;
-let argData_char: ArgumentDataElement;
-let argData_string: ArgumentDataElement;
-let argData_boolean: ArgumentDataElement;
+let argData: ArgumentDataElement;
 let argExpr: ArgumentExpressionElement;
 
 describe('class ArgumentDataElement', () => {
-    test('intialize object with a TInt(5) and verify contents', () => {
-        argData_int = new CArgumentDataElement('myArgData', new TInt(5));
-        expect(argData_int.elementName).toBe('myArgData');
-        expect(argData_int.argType).toBe('data');
-        expect(argData_int.data.value).toBe(5);
-    });
-
-    test('intialize object with a TFloat(3.14) and verify contents', () => {
-        argData_float = new CArgumentDataElement('myArgData', new TFloat(3.14));
-        expect(argData_float.elementName).toBe('myArgData');
-        expect(argData_float.argType).toBe('data');
-        expect(argData_float.data.value).toBe(3.14);
-    });
-
-    test('intialize object with a TChar(65) and verify contents', () => {
-        argData_char = new CArgumentDataElement('myArgData', new TChar(65));
-        expect(argData_char.elementName).toBe('myArgData');
-        expect(argData_char.argType).toBe('data');
-        expect(argData_char.data.value).toBe('A');
-    });
-
-    test('intialize object with a TString("str") and verify contents', () => {
-        argData_string = new CArgumentDataElement('myArgData', new TString('str'));
-        expect(argData_string.elementName).toBe('myArgData');
-        expect(argData_string.argType).toBe('data');
-        expect(argData_string.data.value).toBe('str');
-    });
-
-    test('intialize object with a TBoolean(false) and verify contents', () => {
-        argData_boolean = new CArgumentDataElement('myArgData', new TBoolean(false));
-        expect(argData_boolean.elementName).toBe('myArgData');
-        expect(argData_boolean.argType).toBe('data');
-        expect(argData_boolean.data.value).toBe(false);
+    test("intialize dummy ArgumentDataElement's subclass with valid arbitrary arguments and verify contents", () => {
+        argData = new CArgumentDataElement('myArgData', 'TInt');
+        expect(argData.elementName).toBe('myArgData');
+        expect(argData.type).toBe('TInt');
+        expect(argData.argType).toBe('data');
+        expect(argData.data.value).toBe(5);
     });
 });
 
 describe('class ArgumentExpressionElement', () => {
-    test('initialize object with valid arbitrary arguments and verify contents', () => {
+    test("initialize dummy ArgumentExpressionElement's subclass with valid arbitrary arguments and verify contents", () => {
         argExpr = new CArgumentExpressionElement('myArgExpression', 'TInt');
         expect(argExpr.elementName).toBe('myArgExpression');
         expect(argExpr.type).toBe('TInt');
         expect(argExpr.argType).toBe('expression');
+        expect(argExpr.data.value).toBe(5);
     });
 });
 
@@ -101,10 +75,10 @@ describe('class StatementElement', () => {
 
     test('assign valid argument for valid argument label and verify', () => {
         try {
-            stmntElem.args.setArg('arg_1', argData_char);
+            stmntElem.args.setArg('arg_1', argData);
             const arg = stmntElem.args.getArg('arg_1');
             if (arg !== null) {
-                expect(arg.data.value).toEqual('A');
+                expect(arg.data.value).toEqual(5);
             }
         } catch (e) {
             console.error(e);
@@ -133,7 +107,7 @@ describe('class StatementElement', () => {
     });
 
     test('try to assign invalid return-type argument for valid argument label and expect error', () => {
-        expect(() => stmntElem.args.setArg('arg_2', argData_int)).toThrowError(
+        expect(() => stmntElem.args.setArg('arg_2', argData)).toThrowError(
             'Invalid argument: "TInt" is not a valid type for "arg_2"'
         );
     });

--- a/src/.prototype/syntaxElements/structureElements.ts
+++ b/src/.prototype/syntaxElements/structureElements.ts
@@ -184,6 +184,20 @@ export abstract class InstructionElement extends SyntaxElement implements TS.IIn
 
     /** Executes when element is encountered by MB program interpretor. */
     abstract onVisit(): void;
+
+    /** Whether current instruction is a dummy instruction */
+    get isDummy() {
+        return this.elementName === 'dummy';
+    }
+}
+
+/** To be treated as a terminating or non-existing instruction */
+export class DummyElement extends InstructionElement {
+    constructor() {
+        super('dummy');
+    }
+
+    onVisit() {}
 }
 
 export abstract class StatementElement extends InstructionElement implements TS.IStatementElement {

--- a/src/.prototype/syntaxElements/structureElements.ts
+++ b/src/.prototype/syntaxElements/structureElements.ts
@@ -126,17 +126,11 @@ export abstract class ArgumentElement extends SyntaxElement implements TS.IArgum
 export abstract class ArgumentDataElement
     extends ArgumentElement
     implements TS.IArgumentDataElement {
-    /** Stores the primitive element that is wrapped. */
-    private _dataElement: TPrimitive;
-
-    constructor(elementName: string, dataElement: TPrimitive) {
-        super(elementName, 'data', dataElement.type);
-        this._dataElement = dataElement;
+    constructor(elementName: string, type: TPrimitiveName) {
+        super(elementName, 'data', type);
     }
 
-    get data() {
-        return this._dataElement;
-    }
+    abstract get data(): TPrimitive;
 }
 
 export abstract class ArgumentExpressionElement


### PR DESCRIPTION
`structureElements.ts`:

- Remove private `TPrimitive` object for `ArgumentDataElement`
- Add Dummy Instruction Element `DummyElement`

`structureElements.test.ts`

- Update tests

`conditionalElements.ts`

- Add `argCondition` getter and setter for argument label `condition`

`loopElements.ts`

- Fix internal logic of `RepeatLoopElement`

`loopElements.test.ts`

- Update tests

`miscellaneousElements.ts`

- Add dummy `PrintElement` for demonstration

`valueElements.ts`

- Store private `TPrimitive` object in `ValueElement` which was removed from `ArgumentDataElement`
- Add `DataValueElement`

`dataElements.ts`

- Add getters for `ValueElement` and `TPrimitive` data references in generated `DataValueElement`

`dataElements.test.ts`

- Update tests