### PR TITLE
Ambient properties for syntax element execution

### DIFF
--- a/src/.prototype/broker/@types/syntaxHandler.d.ts
+++ b/src/.prototype/broker/@types/syntaxHandler.d.ts
@@ -1,3 +1,6 @@
+import { IAST } from '../../syntax-core/@types/AST';
+import { ISyntaxElement } from '../../syntax-core/@types/structureElements';
+
 type TQuery =
     | {
           action: 'create';
@@ -31,4 +34,14 @@ type TQuery =
 export interface ISyntaxHandler {
     /** Processes all messages related to syntax and returns acknowledgement or throws error. */
     processQuery: (query: TQuery) => string;
+    /** Returns the corresponding syntax element for an elementID. */
+    getElement: (
+        elementID: string
+    ) => {
+        elementName: string;
+        element: ISyntaxElement;
+        type: 'statement' | 'block' | 'arg-data' | 'arg-exp';
+    };
+    /** Returns the AST object. */
+    AST: IAST;
 }

--- a/src/.prototype/broker/@types/syntaxHandler.d.ts
+++ b/src/.prototype/broker/@types/syntaxHandler.d.ts
@@ -1,11 +1,12 @@
 import { IAST } from '../../syntax-core/@types/AST';
 import { ISyntaxElement } from '../../syntax-core/@types/structureElements';
+import { TSyntaxElementName } from '../../syntax-core/syntaxElementFactory';
 
 type TQuery =
     | {
           action: 'create';
           props: {
-              elementName: string;
+              elementName: TSyntaxElementName;
               arg?: number | string;
           };
       }

--- a/src/.prototype/broker/syntaxHandler.test.ts
+++ b/src/.prototype/broker/syntaxHandler.test.ts
@@ -87,7 +87,7 @@ describe("related to SyntaxElement objects' organization", () => {
             expect(intElemProps.elementName).toBe('int');
             expect(intElemProps.type).toBe('arg-data');
             expect(intElemProps.element.elementName).toBe('int');
-            expect((intElemProps.element as ArgumentElement).getData().value).toBe(5);
+            expect((intElemProps.element as ArgumentElement).getData({}).value).toBe(5);
         });
 
         test('create a start element and verify', () => {
@@ -153,7 +153,7 @@ describe("related to SyntaxElement objects' organization", () => {
             if (element !== null) {
                 expect(element.type).toBe('TInt');
                 expect(element.elementName).toBe('int');
-                expect(element.getData().value).toBe(5);
+                expect(element.getData({}).value).toBe(5);
             } else {
                 throw Error('Object cannot not be null.');
             }
@@ -171,7 +171,7 @@ describe("related to SyntaxElement objects' organization", () => {
             if (element !== null) {
                 expect(element.type).toBe('TFloat');
                 expect(element.elementName).toBe('float');
-                expect(element.getData().value).toBe(3);
+                expect(element.getData({}).value).toBe(3);
             } else {
                 throw Error('Object cannot not be null.');
             }

--- a/src/.prototype/broker/syntaxHandler.test.ts
+++ b/src/.prototype/broker/syntaxHandler.test.ts
@@ -87,7 +87,7 @@ describe("related to SyntaxElement objects' organization", () => {
             expect(intElemProps.elementName).toBe('int');
             expect(intElemProps.type).toBe('arg-data');
             expect(intElemProps.element.elementName).toBe('int');
-            expect((intElemProps.element as ArgumentElement).data.value).toBe(5);
+            expect((intElemProps.element as ArgumentElement).getData().value).toBe(5);
         });
 
         test('create a start element and verify', () => {
@@ -153,7 +153,7 @@ describe("related to SyntaxElement objects' organization", () => {
             if (element !== null) {
                 expect(element.type).toBe('TInt');
                 expect(element.elementName).toBe('int');
-                expect(element.data.value).toBe(5);
+                expect(element.getData().value).toBe(5);
             } else {
                 throw Error('Object cannot not be null.');
             }
@@ -171,7 +171,7 @@ describe("related to SyntaxElement objects' organization", () => {
             if (element !== null) {
                 expect(element.type).toBe('TFloat');
                 expect(element.elementName).toBe('float');
-                expect(element.data.value).toBe(3);
+                expect(element.getData().value).toBe(3);
             } else {
                 throw Error('Object cannot not be null.');
             }

--- a/src/.prototype/broker/syntaxHandler.ts
+++ b/src/.prototype/broker/syntaxHandler.ts
@@ -38,7 +38,7 @@ export default class SyntaxHandler implements ISyntaxHandler {
     }
 
     /** Handles creation of syntax elements. */
-    private _handleCreate(elementName: string, arg?: number | string): string {
+    private _handleCreate(elementName: Factory.TSyntaxElementName, arg?: number | string): string {
         const id = this._newID;
         switch (elementName) {
             case 'start':

--- a/src/.prototype/broker/syntaxHandler.ts
+++ b/src/.prototype/broker/syntaxHandler.ts
@@ -10,6 +10,7 @@ import {
 } from '../syntax-core/structureElements';
 import * as Factory from '../syntax-core/syntaxElementFactory';
 import { AST, StartBlock } from '../syntax-core/AST';
+import { SymbolTable } from '../syntax-core/symbolTable';
 
 export default class SyntaxHandler implements ISyntaxHandler {
     private _elementMap: {
@@ -20,9 +21,11 @@ export default class SyntaxHandler implements ISyntaxHandler {
         };
     } = {};
     private _AST: AST;
+    private _symbolTable: SymbolTable;
 
     constructor() {
         this._AST = new AST();
+        this._symbolTable = new SymbolTable();
     }
 
     // -- Utilities ------------------------------------------------------------
@@ -196,5 +199,9 @@ export default class SyntaxHandler implements ISyntaxHandler {
 
     get AST(): AST {
         return this._AST;
+    }
+
+    get symbolTable(): SymbolTable {
+        return this._symbolTable;
     }
 }

--- a/src/.prototype/syntax-core/@types/AST.d.ts
+++ b/src/.prototype/syntax-core/@types/AST.d.ts
@@ -5,6 +5,12 @@ export interface IStartBlock extends IBlockElement {}
 export interface IActionBlock extends IBlockElement {}
 
 export interface IAST {
+    /** Returns list of 'start' elements. */
     startBlocks: IStartBlock[];
+    /** Returns list of 'action' elements. */
     actionBlocks: IActionBlock[];
+    /** Creates a new 'start' element and add it to 'start' blocks list. */
+    addStart: Function;
+    /** Removes a 'start' element from 'start' blocks list. */
+    removeStart: Function;
 }

--- a/src/.prototype/syntax-core/@types/context.d.ts
+++ b/src/.prototype/syntax-core/@types/context.d.ts
@@ -1,1 +1,2 @@
+/** Stores the instrinsic music and art properties associated with the current context. */
 export interface IContext {}

--- a/src/.prototype/syntax-core/@types/structureElements.d.ts
+++ b/src/.prototype/syntax-core/@types/structureElements.d.ts
@@ -1,5 +1,6 @@
 import { TPrimitive, TPrimitiveName } from './primitiveTypes';
 import { IContext } from './context';
+import { ISymbolTable } from './symbolTable';
 
 /**
  * There are two categories of syntax elements: Arguments and Instructions.
@@ -43,7 +44,7 @@ export interface IArgumentElement extends ISyntaxElement {
     /** Return type of the argument element. */
     type: TPrimitiveName;
     /** Returns the primitive element that the argument element returns. */
-    getData: (props: { context?: IContext; args?: { [key: string]: TPrimitive } }) => TPrimitive;
+    getData: Function;
 }
 
 /**
@@ -70,7 +71,7 @@ interface IInstructionElement extends ISyntaxElement {
     /** Stores the reference to the next instruction in stack. */
     next: IInstructionElement | null;
     /** Triggered before instruction is executed. */
-    onVisit: (props: { context?: IContext; args?: { [key: string]: TPrimitive } }) => void;
+    onVisit: Function;
 }
 
 /**
@@ -91,5 +92,5 @@ export interface IBlockElement extends IInstructionElement {
     /** Initial head instruction. */
     childHead: IInstructionElement | null;
     /** Triggered after block instruction is executed. */
-    onExit: (props: { context?: IContext; args?: { [key: string]: TPrimitive } }) => void;
+    onExit: Function;
 }

--- a/src/.prototype/syntax-core/@types/structureElements.d.ts
+++ b/src/.prototype/syntax-core/@types/structureElements.d.ts
@@ -45,7 +45,7 @@ export interface IArgumentElement extends ISyntaxElement {
     /** Return type of the argument element. */
     type: TPrimitiveName;
     /** Returns the primitive element that the argument element returns. */
-    getData: (context?: IContext) => TPrimitive;
+    getData: (props: { context?: IContext; args?: { [key: string]: TPrimitive } }) => TPrimitive;
 }
 
 /**
@@ -72,7 +72,7 @@ interface IInstructionElement extends ISyntaxElement {
     /** Stores the reference to the next instruction in stack. */
     next: IInstructionElement | null;
     /** Triggered before instruction is executed. */
-    onVisit: (context?: IContext) => void;
+    onVisit: (props: { context?: IContext; args?: { [key: string]: TPrimitive } }) => void;
 }
 
 /**
@@ -93,5 +93,5 @@ export interface IBlockElement extends IInstructionElement {
     /** Initial head instruction. */
     childHead: IInstructionElement | null;
     /** Triggered after block instruction is executed. */
-    onExit: (context?: IContext) => void;
+    onExit: (props: { context?: IContext; args?: { [key: string]: TPrimitive } }) => void;
 }

--- a/src/.prototype/syntax-core/@types/structureElements.d.ts
+++ b/src/.prototype/syntax-core/@types/structureElements.d.ts
@@ -15,8 +15,6 @@ import { IContext } from './context';
 export interface ISyntaxElement {
     /** Name of the supported syntax element. Different from identifiers. */
     elementName: string;
-    /** Whether argument requires a context. */
-    requiresContext: boolean;
 }
 
 export interface IDataElement {}

--- a/src/.prototype/syntax-core/@types/structureElements.d.ts
+++ b/src/.prototype/syntax-core/@types/structureElements.d.ts
@@ -15,16 +15,11 @@ import { IContext } from './context';
 export interface ISyntaxElement {
     /** Name of the supported syntax element. Different from identifiers. */
     elementName: string;
-    /** Stores the instrinsic music and art properties associated with the current context. */
-    context: IContext | null;
     /** Whether argument requires a context. */
     requiresContext: boolean;
 }
 
-export interface IDataElement {
-    /** A primitive element. */
-    data: TPrimitive;
-}
+export interface IDataElement {}
 
 export interface IExpressionElement {}
 
@@ -34,12 +29,14 @@ export interface IExpressionElement {}
  */
 export interface IArgumentMap {
     /** Returns the list of argument labels. */
-    argNames: string[];
+    argLabels: string[];
     /** Assigns an ArgumentElement | null corresponding to an argument label. */
     setArg: Function;
     /** Returns the ArgumentElement | null corresponding to an argument label. */
     getArg: Function;
 }
+
+// ---- Argument elements --------------------------------------------------------------------------
 
 /** To be implemented by the super-class of all argument elements. */
 export interface IArgumentElement extends ISyntaxElement {
@@ -48,23 +45,25 @@ export interface IArgumentElement extends ISyntaxElement {
     /** Return type of the argument element. */
     type: TPrimitiveName;
     /** Returns the primitive element that the argument element returns. */
-    data: TPrimitive;
+    getData: (context?: IContext) => TPrimitive;
 }
 
 /**
  * To be implemented by sub-classes of class that implement IArgumentElement and represent data
  * arguments.
  */
-export interface IArgumentDataElement extends ISyntaxElement, IDataElement {}
+export interface IArgumentDataElement extends IArgumentElement, IDataElement {}
 
 /**
  * To be implemented by sub-classes of class that implement IArgumentElement and represent
  * expression arguments.
  */
-export interface IArgumentExpressionElement extends ISyntaxElement, IExpressionElement {
+export interface IArgumentExpressionElement extends IArgumentElement, IExpressionElement {
     /** Stores an object of the class that implements IArgumentMap. */
     args: IArgumentMap;
 }
+
+// ---- Instruction elements -----------------------------------------------------------------------
 
 /** To be implemented by the super-class of all instruction elements. */
 interface IInstructionElement extends ISyntaxElement {
@@ -72,6 +71,8 @@ interface IInstructionElement extends ISyntaxElement {
     args: IArgumentMap;
     /** Stores the reference to the next instruction in stack. */
     next: IInstructionElement | null;
+    /** Triggered before instruction is executed. */
+    onVisit: (context?: IContext) => void;
 }
 
 /**
@@ -91,4 +92,6 @@ export interface IBlockElement extends IInstructionElement {
     getChildHead: (index: number) => IInstructionElement | null;
     /** Initial head instruction. */
     childHead: IInstructionElement | null;
+    /** Triggered after block instruction is executed. */
+    onExit: (context?: IContext) => void;
 }

--- a/src/.prototype/syntax-core/@types/symbolTable.d.ts
+++ b/src/.prototype/syntax-core/@types/symbolTable.d.ts
@@ -1,0 +1,8 @@
+import { TBoolean, TString } from '../primitiveElements';
+import { TPrimitive, TPrimitiveName } from './primitiveTypes';
+
+export interface ISymbolTable {
+    symbolExists: (symbol: TString) => TBoolean;
+    addSymbol: (symbol: TString, data: TPrimitive) => void;
+    getSymbolData: (symbol: TString) => TPrimitive;
+}

--- a/src/.prototype/syntax-core/AST.ts
+++ b/src/.prototype/syntax-core/AST.ts
@@ -5,9 +5,15 @@ import { Context } from './context';
 // ---- Top Level Blocks (Start and Action) --------------------------------------------------------
 
 export class StartBlock extends BlockElement implements IStartBlock {
+    private _context: Context;
+
     constructor() {
-        super('start', 1);
-        this.context = new Context();
+        super('start', 1, false);
+        this._context = new Context();
+    }
+
+    get context() {
+        return this._context;
     }
 
     onVisit() {}

--- a/src/.prototype/syntax-core/AST.ts
+++ b/src/.prototype/syntax-core/AST.ts
@@ -30,24 +30,10 @@ export class ActionBlock extends BlockElement implements IActionBlock {
 // ---- Abstract Syntax Tree (AST) -----------------------------------------------------------------
 
 export class AST implements IAST {
-    /** Stores the singleton instance (once instantiated). */
-    private static _instance: AST | undefined;
-
     private _startBlocks: StartBlock[] = [];
     private _actionBlocks: ActionBlock[] = [];
 
-    /** Creates and returns a new instance of the class if one doesn't exist, else returns the existing one. */
-    constructor() {
-        if (AST._instance) {
-            return AST._instance;
-        }
-        AST._instance = this;
-    }
-
-    /** Getter that returns the singleton instance. */
-    static get instance() {
-        return AST._instance;
-    }
+    constructor() {}
 
     get startBlocks() {
         return this._startBlocks;
@@ -57,15 +43,18 @@ export class AST implements IAST {
         return this._actionBlocks;
     }
 
-    get newStart() {
-        const start = new StartBlock();
-        this._startBlocks.push(start);
-        return start;
+    addStart(): StartBlock {
+        const startElement = new StartBlock();
+        this._startBlocks.push(startElement);
+        return startElement;
     }
 
-    get newAction() {
-        const action = new ActionBlock();
-        this._actionBlocks.push(action);
-        return action;
+    removeStart(startElement: StartBlock) {
+        const index = this._startBlocks.indexOf(startElement);
+        if (index !== -1) {
+            this._startBlocks.splice(index, 1);
+        } else {
+            throw Error(`Start block does not exist in AST.`);
+        }
     }
 }

--- a/src/.prototype/syntax-core/AST.ts
+++ b/src/.prototype/syntax-core/AST.ts
@@ -8,7 +8,7 @@ export class StartBlock extends BlockElement implements IStartBlock {
     private _context: Context;
 
     constructor() {
-        super('start', 1, false);
+        super('start', 1);
         this._context = new Context();
     }
 
@@ -23,7 +23,7 @@ export class StartBlock extends BlockElement implements IStartBlock {
 
 export class ActionBlock extends BlockElement implements IActionBlock {
     constructor() {
-        super('action', 1, true, {
+        super('action', 1, {
             name: ['TString']
         });
     }

--- a/src/.prototype/syntax-core/program-elements/conditionalElements.test.ts
+++ b/src/.prototype/syntax-core/program-elements/conditionalElements.test.ts
@@ -8,8 +8,8 @@ class CStatementElement extends StatementElement {
 }
 
 describe('namespace ConditionalElement', () => {
-    const statement_1 = new CStatementElement('statement-1', false);
-    const statement_2 = new CStatementElement('statement-2', false);
+    const statement_1 = new CStatementElement('statement-1');
+    const statement_2 = new CStatementElement('statement-2');
 
     describe('class IfElseElement', () => {
         const ifElseElem = new ConditionalElement.IfElseElement();

--- a/src/.prototype/syntax-core/program-elements/conditionalElements.test.ts
+++ b/src/.prototype/syntax-core/program-elements/conditionalElements.test.ts
@@ -8,8 +8,8 @@ class CStatementElement extends StatementElement {
 }
 
 describe('namespace ConditionalElement', () => {
-    const statement_1 = new CStatementElement('statement-1');
-    const statement_2 = new CStatementElement('statement-2');
+    const statement_1 = new CStatementElement('statement-1', false);
+    const statement_2 = new CStatementElement('statement-2', false);
 
     describe('class IfElseElement', () => {
         const ifElseElem = new ConditionalElement.IfElseElement();

--- a/src/.prototype/syntax-core/program-elements/conditionalElements.test.ts
+++ b/src/.prototype/syntax-core/program-elements/conditionalElements.test.ts
@@ -21,7 +21,7 @@ describe('namespace ConditionalElement', () => {
             ifElseElem.args.setArg('condition', argElem);
             ifElseElem.onVisit({
                 args: {
-                    condition: argElem.getData()
+                    condition: argElem.getData({})
                 }
             });
             const childHead = ifElseElem.childHead;
@@ -37,7 +37,7 @@ describe('namespace ConditionalElement', () => {
             ifElseElem.args.setArg('condition', argElem);
             ifElseElem.onVisit({
                 args: {
-                    condition: argElem.getData()
+                    condition: argElem.getData({})
                 }
             });
             const childHead = ifElseElem.childHead;
@@ -65,7 +65,7 @@ describe('namespace ConditionalElement', () => {
             IfThenElem.args.setArg('condition', argElem);
             IfThenElem.onVisit({
                 args: {
-                    condition: argElem.getData()
+                    condition: argElem.getData({})
                 }
             });
             const childHead = IfThenElem.childHead;
@@ -81,7 +81,7 @@ describe('namespace ConditionalElement', () => {
             IfThenElem.args.setArg('condition', argElem);
             IfThenElem.onVisit({
                 args: {
-                    condition: argElem.getData()
+                    condition: argElem.getData({})
                 }
             });
             const childHead = IfThenElem.childHead;

--- a/src/.prototype/syntax-core/program-elements/conditionalElements.test.ts
+++ b/src/.prototype/syntax-core/program-elements/conditionalElements.test.ts
@@ -17,8 +17,13 @@ describe('namespace ConditionalElement', () => {
         ifElseElem.setChildHead(1, statement_2);
 
         test("pass a valid true condition and expect childHead to be first block's head", () => {
-            ifElseElem.args.setArg('condition', new ValueElement.TrueElement());
-            ifElseElem.onVisit();
+            const argElem = new ValueElement.TrueElement();
+            ifElseElem.args.setArg('condition', argElem);
+            ifElseElem.onVisit({
+                args: {
+                    condition: argElem.getData()
+                }
+            });
             const childHead = ifElseElem.childHead;
             if (childHead !== null) {
                 expect(childHead.elementName).toBe('statement-1');
@@ -28,8 +33,13 @@ describe('namespace ConditionalElement', () => {
         });
 
         test("pass a valid false condition and expect childHead to be second block's head", () => {
-            ifElseElem.args.setArg('condition', new ValueElement.FalseElement());
-            ifElseElem.onVisit();
+            const argElem = new ValueElement.FalseElement();
+            ifElseElem.args.setArg('condition', argElem);
+            ifElseElem.onVisit({
+                args: {
+                    condition: argElem.getData()
+                }
+            });
             const childHead = ifElseElem.childHead;
             if (childHead !== null) {
                 expect(childHead.elementName).toBe('statement-2');
@@ -38,12 +48,12 @@ describe('namespace ConditionalElement', () => {
             }
         });
 
-        test('pass a null as condition and expect error', () => {
-            ifElseElem.args.setArg('condition', null);
-            expect(() => ifElseElem.onVisit()).toThrowError(
-                'Invalid argument: condition cannot be null'
-            );
-        });
+        // test('pass a null as condition and expect error', () => {
+        //     ifElseElem.args.setArg('condition', null);
+        //     expect(() => ifElseElem.onVisit()).toThrowError(
+        //         'Invalid argument: condition cannot be null'
+        //     );
+        // });
     });
 
     describe('class IfThenElement', () => {
@@ -51,8 +61,13 @@ describe('namespace ConditionalElement', () => {
         IfThenElem.setChildHead(0, statement_1);
 
         test("pass a valid true condition and expect childHead to be first block's head", () => {
-            IfThenElem.args.setArg('condition', new ValueElement.TrueElement());
-            IfThenElem.onVisit();
+            const argElem = new ValueElement.TrueElement();
+            IfThenElem.args.setArg('condition', argElem);
+            IfThenElem.onVisit({
+                args: {
+                    condition: argElem.getData()
+                }
+            });
             const childHead = IfThenElem.childHead;
             if (childHead !== null) {
                 expect(childHead.elementName).toBe('statement-1');
@@ -62,17 +77,22 @@ describe('namespace ConditionalElement', () => {
         });
 
         test('pass a valid false condition and expect childHead to be null', () => {
-            IfThenElem.args.setArg('condition', new ValueElement.FalseElement());
-            IfThenElem.onVisit();
+            const argElem = new ValueElement.FalseElement();
+            IfThenElem.args.setArg('condition', argElem);
+            IfThenElem.onVisit({
+                args: {
+                    condition: argElem.getData()
+                }
+            });
             const childHead = IfThenElem.childHead;
             expect(childHead).toBe(null);
         });
 
-        test('pass a null as condition and expect error', () => {
-            IfThenElem.args.setArg('condition', null);
-            expect(() => IfThenElem.onVisit()).toThrowError(
-                'Invalid argument: condition cannot be null'
-            );
-        });
+        // test('pass a null as condition and expect error', () => {
+        //     IfThenElem.args.setArg('condition', null);
+        //     expect(() => IfThenElem.onVisit()).toThrowError(
+        //         'Invalid argument: condition cannot be null'
+        //     );
+        // });
     });
 });

--- a/src/.prototype/syntax-core/program-elements/conditionalElements.ts
+++ b/src/.prototype/syntax-core/program-elements/conditionalElements.ts
@@ -4,7 +4,7 @@ import { BlockElement } from '../structureElements';
 export namespace ConditionalElement {
     export class IfElseElement extends BlockElement {
         constructor(elementName?: 'if') {
-            super(elementName !== undefined ? elementName : 'if-else', 2, false, {
+            super(elementName !== undefined ? elementName : 'if-else', 2, {
                 condition: ['TBoolean']
             });
         }

--- a/src/.prototype/syntax-core/program-elements/conditionalElements.ts
+++ b/src/.prototype/syntax-core/program-elements/conditionalElements.ts
@@ -1,4 +1,5 @@
-import { ArgumentElement, BlockElement } from '../structureElements';
+import { TPrimitive } from '../@types/primitiveTypes';
+import { BlockElement } from '../structureElements';
 
 export namespace ConditionalElement {
     export class IfElseElement extends BlockElement {
@@ -8,21 +9,8 @@ export namespace ConditionalElement {
             });
         }
 
-        set argCondition(condition: ArgumentElement | null) {
-            this.args.setArg('condition', condition);
-        }
-
-        get argCondition() {
-            return this.args.getArg('condition');
-        }
-
-        /** @throws Invalid argument */
-        onVisit() {
-            const arg = this.args.getArg('condition');
-            if (arg === null) {
-                throw Error('Invalid argument: condition cannot be null');
-            }
-            this.childHead = this.getChildHead(arg.getData().value ? 0 : 1);
+        onVisit(props: { args: { condition: TPrimitive } }) {
+            this.childHead = this.getChildHead(props.args['condition'].value ? 0 : 1);
         }
 
         onExit() {}

--- a/src/.prototype/syntax-core/program-elements/conditionalElements.ts
+++ b/src/.prototype/syntax-core/program-elements/conditionalElements.ts
@@ -22,7 +22,7 @@ export namespace ConditionalElement {
             if (arg === null) {
                 throw Error('Invalid argument: condition cannot be null');
             }
-            this.childHead = this.getChildHead(arg.data.value ? 0 : 1);
+            this.childHead = this.getChildHead(arg.getData().value ? 0 : 1);
         }
 
         onExit() {}

--- a/src/.prototype/syntax-core/program-elements/dataElements.test.ts
+++ b/src/.prototype/syntax-core/program-elements/dataElements.test.ts
@@ -9,9 +9,9 @@ describe('namespace DataElement', () => {
             dataElem.argValue = new ValueElement.IntElement(5);
             const arg = dataElem.args.getArg('value');
             if (arg !== null) {
-                expect(arg.data.value).toBe(5);
+                expect(arg.getData().value).toBe(5);
             } else {
-                throw Error('Object should not be null');
+                throw Error('Object should not be null.');
             }
         });
 
@@ -20,7 +20,7 @@ describe('namespace DataElement', () => {
                 const dataElem = new DataElement.IntDataElement();
                 dataElem.argIdentifier = new ValueElement.StringElement('myBox');
                 dataElem.argValue = new ValueElement.TrueElement();
-            }).toThrowError('Invalid argument: "TBoolean" is not a valid type for "value"');
+            }).toThrowError('"TBoolean" is not a valid type for "value".');
         });
 
         test('initialize FloatDataElement with FloatElement object and verify', () => {
@@ -29,9 +29,9 @@ describe('namespace DataElement', () => {
             dataElem.argValue = new ValueElement.FloatElement(5.234);
             const arg = dataElem.args.getArg('value');
             if (arg !== null) {
-                expect(arg.data.value).toBe(5.234);
+                expect(arg.getData().value).toBe(5.234);
             } else {
-                throw Error('Object should not be null');
+                throw Error('Object should not be null.');
             }
         });
 
@@ -40,7 +40,7 @@ describe('namespace DataElement', () => {
                 const dataElem = new DataElement.FloatDataElement();
                 dataElem.argIdentifier = new ValueElement.StringElement('myBox');
                 dataElem.argValue = new ValueElement.TrueElement();
-            }).toThrowError('Invalid argument: "TBoolean" is not a valid type for "value"');
+            }).toThrowError('"TBoolean" is not a valid type for "value".');
         });
 
         test('initialize CharDataElement with CharElement object and verify', () => {
@@ -49,9 +49,9 @@ describe('namespace DataElement', () => {
             dataElem.argValue = new ValueElement.CharElement(97);
             const arg = dataElem.args.getArg('value');
             if (arg !== null) {
-                expect(arg.data.value).toBe('a');
+                expect(arg.getData().value).toBe('a');
             } else {
-                throw Error('Object should not be null');
+                throw Error('Object should not be null.');
             }
         });
 
@@ -60,7 +60,7 @@ describe('namespace DataElement', () => {
                 const dataElem = new DataElement.CharDataElement();
                 dataElem.argIdentifier = new ValueElement.StringElement('myBox');
                 dataElem.argValue = new ValueElement.TrueElement();
-            }).toThrowError('Invalid argument: "TBoolean" is not a valid type for "value"');
+            }).toThrowError('"TBoolean" is not a valid type for "value".');
         });
 
         test('initialize StringDataElement with StringElement object and verify', () => {
@@ -69,9 +69,9 @@ describe('namespace DataElement', () => {
             dataElem.argValue = new ValueElement.StringElement('string');
             const arg = dataElem.args.getArg('value');
             if (arg !== null) {
-                expect(arg.data.value).toBe('string');
+                expect(arg.getData().value).toBe('string');
             } else {
-                throw Error('Object should not be null');
+                throw Error('Object should not be null.');
             }
         });
 
@@ -80,7 +80,7 @@ describe('namespace DataElement', () => {
                 const dataElem = new DataElement.StringDataElement();
                 dataElem.argIdentifier = new ValueElement.StringElement('myBox');
                 dataElem.argValue = new ValueElement.TrueElement();
-            }).toThrowError('Invalid argument: "TBoolean" is not a valid type for "value"');
+            }).toThrowError('"TBoolean" is not a valid type for "value".');
         });
 
         test('initialize BooleanDataElement with BooleanElement object and verify', () => {
@@ -89,9 +89,9 @@ describe('namespace DataElement', () => {
             dataElem.argValue = new ValueElement.TrueElement();
             const arg = dataElem.args.getArg('value');
             if (arg !== null) {
-                expect(arg.data.value).toBe(true);
+                expect(arg.getData().value).toBe(true);
             } else {
-                throw Error('Object should not be null');
+                throw Error('Object should not be null.');
             }
         });
 
@@ -100,7 +100,7 @@ describe('namespace DataElement', () => {
                 const dataElem = new DataElement.BooleanDataElement();
                 dataElem.argIdentifier = new ValueElement.StringElement('myBox');
                 dataElem.argValue = new ValueElement.IntElement(5);
-            }).toThrowError('Invalid argument: "TInt" is not a valid type for "value"');
+            }).toThrowError('"TInt" is not a valid type for "value".');
         });
 
         // test('initialize AnyDataElement with StringElement object and verify', () => {
@@ -123,8 +123,8 @@ describe('namespace DataElement', () => {
             dataElem.argValue = new ValueElement.IntElement(5);
             const valueElement = dataElem.valueElement;
             expect(valueElement instanceof ValueElement.IntDataValueElement).toBe(true);
-            expect(valueElement.data.value).toBe(5);
-            const dataElement = valueElement.data;
+            expect(valueElement.getData().value).toBe(5);
+            const dataElement = valueElement.getData();
             expect(dataElement).toEqual(dataElem.dataElementRef);
         });
 
@@ -132,9 +132,7 @@ describe('namespace DataElement', () => {
             const dataElem = new DataElement.IntDataElement();
             dataElem.argIdentifier = new ValueElement.StringElement('myBox');
             dataElem.argValue = null;
-            expect(() => dataElem.dataElementRef).toThrowError(
-                'Invalid argument: value cannot be null'
-            );
+            expect(() => dataElem.dataElementRef).toThrowError('Value cannot be null.');
         });
 
         test('verify reference in created DataValueElement after assigning a FloatDataElement', () => {
@@ -144,8 +142,8 @@ describe('namespace DataElement', () => {
             dataElem.onVisit();
             const valueElement = dataElem.valueElement;
             expect(valueElement instanceof ValueElement.FloatDataValueElement).toBe(true);
-            expect(valueElement.data.value).toBe(2.71828);
-            const dataElement = valueElement.data;
+            expect(valueElement.getData().value).toBe(2.71828);
+            const dataElement = valueElement.getData();
             expect(dataElement).toEqual(dataElem.dataElementRef);
         });
 
@@ -153,9 +151,7 @@ describe('namespace DataElement', () => {
             const dataElem = new DataElement.FloatDataElement();
             dataElem.argIdentifier = new ValueElement.StringElement('myBox');
             dataElem.argValue = null;
-            expect(() => dataElem.dataElementRef).toThrowError(
-                'Invalid argument: value cannot be null'
-            );
+            expect(() => dataElem.dataElementRef).toThrowError('Value cannot be null.');
         });
 
         test('verify reference in created DataValueElement after assigning a CharDataElement', () => {
@@ -165,8 +161,8 @@ describe('namespace DataElement', () => {
             dataElem.onVisit();
             const valueElement = dataElem.valueElement;
             expect(valueElement instanceof ValueElement.CharDataValueElement).toBe(true);
-            expect(valueElement.data.value).toBe('a');
-            const dataElement = valueElement.data;
+            expect(valueElement.getData().value).toBe('a');
+            const dataElement = valueElement.getData();
             expect(dataElement).toEqual(dataElem.dataElementRef);
         });
 
@@ -174,9 +170,7 @@ describe('namespace DataElement', () => {
             const dataElem = new DataElement.CharDataElement();
             dataElem.argIdentifier = new ValueElement.StringElement('myBox');
             dataElem.argValue = null;
-            expect(() => dataElem.dataElementRef).toThrowError(
-                'Invalid argument: value cannot be null'
-            );
+            expect(() => dataElem.dataElementRef).toThrowError('Value cannot be null.');
         });
 
         test('verify reference in created DataValueElement after assigning a StringDataElement', () => {
@@ -186,8 +180,8 @@ describe('namespace DataElement', () => {
             dataElem.onVisit();
             const valueElement = dataElem.valueElement;
             expect(valueElement instanceof ValueElement.StringDataValueElement).toBe(true);
-            expect(valueElement.data.value).toBe('string');
-            const dataElement = valueElement.data;
+            expect(valueElement.getData().value).toBe('string');
+            const dataElement = valueElement.getData();
             expect(dataElement).toEqual(dataElem.dataElementRef);
         });
 
@@ -195,9 +189,7 @@ describe('namespace DataElement', () => {
             const dataElem = new DataElement.StringDataElement();
             dataElem.argIdentifier = new ValueElement.StringElement('myBox');
             dataElem.argValue = null;
-            expect(() => dataElem.dataElementRef).toThrowError(
-                'Invalid argument: value cannot be null'
-            );
+            expect(() => dataElem.dataElementRef).toThrowError('Value cannot be null.');
         });
 
         test('verify reference in created DataValueElement after assigning a BooleanDataElement with TrueElement', () => {
@@ -207,8 +199,8 @@ describe('namespace DataElement', () => {
             dataElem.onVisit();
             const valueElement = dataElem.valueElement;
             expect(valueElement instanceof ValueElement.BooleanDataValueElement).toBe(true);
-            expect(valueElement.data.value).toBe(true);
-            const dataElement = valueElement.data;
+            expect(valueElement.getData().value).toBe(true);
+            const dataElement = valueElement.getData();
             expect(dataElement).toEqual(dataElem.dataElementRef);
         });
 
@@ -219,8 +211,8 @@ describe('namespace DataElement', () => {
             dataElem.onVisit();
             const valueElement = dataElem.valueElement;
             expect(valueElement instanceof ValueElement.BooleanDataValueElement).toBe(true);
-            expect(valueElement.data.value).toBe(false);
-            const dataElement = valueElement.data;
+            expect(valueElement.getData().value).toBe(false);
+            const dataElement = valueElement.getData();
             expect(dataElement).toEqual(dataElem.dataElementRef);
         });
 
@@ -228,9 +220,7 @@ describe('namespace DataElement', () => {
             const dataElem = new DataElement.BooleanDataElement();
             dataElem.argIdentifier = new ValueElement.StringElement('myBox');
             dataElem.argValue = null;
-            expect(() => dataElem.dataElementRef).toThrowError(
-                'Invalid argument: value cannot be null'
-            );
+            expect(() => dataElem.dataElementRef).toThrowError('Value cannot be null.');
         });
 
         // test('verify created ValueElement after executing a AnyDataElement', () => {

--- a/src/.prototype/syntax-core/program-elements/dataElements.test.ts
+++ b/src/.prototype/syntax-core/program-elements/dataElements.test.ts
@@ -1,3 +1,4 @@
+import { SymbolTable } from '../symbolTable';
 import { DataElement } from './dataElements';
 import { ValueElement } from './valueElements';
 
@@ -116,112 +117,131 @@ describe('namespace DataElement', () => {
         // });
     });
 
+    const symbolTable = new SymbolTable();
+
     describe('value element verification', () => {
         test('verify reference in created DataValueElement after assigning a IntDataElement', () => {
             const dataElem = new DataElement.IntDataElement();
-            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
-            dataElem.args.setArg('value', new ValueElement.IntElement(5));
+            const argIdentifier = new ValueElement.StringElement('myIntBox');
+            const argValue = new ValueElement.IntElement(5);
+            dataElem.args.setArg('identifier', argIdentifier);
+            dataElem.args.setArg('value', argValue);
+            dataElem.onVisit({
+                args: {
+                    identifier: argIdentifier.getData({}),
+                    value: argValue.getData({})
+                },
+                symbolTable
+            });
             const valueElement = dataElem.valueElement;
             expect(valueElement instanceof ValueElement.IntDataValueElement).toBe(true);
-            expect(valueElement.getData().value).toBe(5);
-            const dataElement = valueElement.getData();
-            expect(dataElement).toEqual(dataElem.dataElementRef);
+            expect(valueElement.getData({ symbolTable }).value).toBe(5);
+            const dataElement = valueElement.getData({ symbolTable });
+            expect(dataElement).toEqual(argValue.getData({}));
         });
 
-        test('attempt to fetch TInt reference while assigning a null as value and expect error', () => {
-            const dataElem = new DataElement.IntDataElement();
-            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
-            dataElem.args.setArg('value', null);
-            expect(() => dataElem.dataElementRef).toThrowError('Value cannot be null.');
-        });
+        // test('attempt to fetch TInt reference while assigning a null as value and expect error', () => {
+        //     const dataElem = new DataElement.IntDataElement();
+        //     dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+        //     dataElem.args.setArg('value', null);
+        //     expect(() => dataElem.dataElementRef).toThrowError('Value cannot be null.');
+        // });
 
         test('verify reference in created DataValueElement after assigning a FloatDataElement', () => {
             const dataElem = new DataElement.FloatDataElement();
-            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
-            dataElem.args.setArg('value', new ValueElement.FloatElement(2.71828));
-            dataElem.onVisit();
+            const argIdentifier = new ValueElement.StringElement('myFloatBox');
+            const argValue = new ValueElement.FloatElement(2.71828);
+            dataElem.args.setArg('identifier', argIdentifier);
+            dataElem.args.setArg('value', argValue);
+            dataElem.onVisit({
+                args: {
+                    identifier: argIdentifier.getData({}),
+                    value: argValue.getData({})
+                },
+                symbolTable
+            });
             const valueElement = dataElem.valueElement;
             expect(valueElement instanceof ValueElement.FloatDataValueElement).toBe(true);
-            expect(valueElement.getData().value).toBe(2.71828);
-            const dataElement = valueElement.getData();
-            expect(dataElement).toEqual(dataElem.dataElementRef);
+            expect(valueElement.getData({ symbolTable }).value).toBe(2.71828);
+            const dataElement = valueElement.getData({ symbolTable });
+            expect(dataElement).toEqual(argValue.getData({}));
         });
 
-        test('attempt to fetch TFloat reference while assigning a null as value and expect error', () => {
-            const dataElem = new DataElement.FloatDataElement();
-            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
-            dataElem.args.setArg('value', null);
-            expect(() => dataElem.dataElementRef).toThrowError('Value cannot be null.');
-        });
+        // test('attempt to fetch TFloat reference while assigning a null as value and expect error', () => {
+        //     const dataElem = new DataElement.FloatDataElement();
+        //     dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+        //     dataElem.args.setArg('value', null);
+        //     expect(() => dataElem.dataElementRef).toThrowError('Value cannot be null.');
+        // });
 
         test('verify reference in created DataValueElement after assigning a CharDataElement', () => {
-            const dataElem = new DataElement.CharDataElement();
-            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
-            dataElem.args.setArg('value', new ValueElement.CharElement(97));
-            dataElem.onVisit();
-            const valueElement = dataElem.valueElement;
-            expect(valueElement instanceof ValueElement.CharDataValueElement).toBe(true);
-            expect(valueElement.getData().value).toBe('a');
-            const dataElement = valueElement.getData();
-            expect(dataElement).toEqual(dataElem.dataElementRef);
+            // const dataElem = new DataElement.CharDataElement();
+            // dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+            // dataElem.args.setArg('value', new ValueElement.CharElement(97));
+            // dataElem.onVisit();
+            // const valueElement = dataElem.valueElement;
+            // expect(valueElement instanceof ValueElement.CharDataValueElement).toBe(true);
+            // expect(valueElement.getData({ symbolTable }).value).toBe('a');
+            // const dataElement = valueElement.getData({ symbolTable });
+            // expect(dataElement).toEqual(dataElem.dataElementRef);
         });
 
-        test('attempt to fetch TChar reference while assigning a null as value and expect error', () => {
-            const dataElem = new DataElement.CharDataElement();
-            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
-            dataElem.args.setArg('value', null);
-            expect(() => dataElem.dataElementRef).toThrowError('Value cannot be null.');
-        });
+        // test('attempt to fetch TChar reference while assigning a null as value and expect error', () => {
+        //     const dataElem = new DataElement.CharDataElement();
+        //     dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+        //     dataElem.args.setArg('value', null);
+        //     expect(() => dataElem.dataElementRef).toThrowError('Value cannot be null.');
+        // });
 
         test('verify reference in created DataValueElement after assigning a StringDataElement', () => {
-            const dataElem = new DataElement.StringDataElement();
-            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
-            dataElem.args.setArg('value', new ValueElement.StringElement('string'));
-            dataElem.onVisit();
-            const valueElement = dataElem.valueElement;
-            expect(valueElement instanceof ValueElement.StringDataValueElement).toBe(true);
-            expect(valueElement.getData().value).toBe('string');
-            const dataElement = valueElement.getData();
-            expect(dataElement).toEqual(dataElem.dataElementRef);
+            // const dataElem = new DataElement.StringDataElement();
+            // dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+            // dataElem.args.setArg('value', new ValueElement.StringElement('string'));
+            // dataElem.onVisit();
+            // const valueElement = dataElem.valueElement;
+            // expect(valueElement instanceof ValueElement.StringDataValueElement).toBe(true);
+            // expect(valueElement.getData({ symbolTable }).value).toBe('string');
+            // const dataElement = valueElement.getData({ symbolTable });
+            // expect(dataElement).toEqual(dataElem.dataElementRef);
         });
 
-        test('attempt to fetch TString reference while assigning a null as value and expect error', () => {
-            const dataElem = new DataElement.StringDataElement();
-            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
-            dataElem.args.setArg('value', null);
-            expect(() => dataElem.dataElementRef).toThrowError('Value cannot be null.');
-        });
+        // test('attempt to fetch TString reference while assigning a null as value and expect error', () => {
+        //     const dataElem = new DataElement.StringDataElement();
+        //     dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+        //     dataElem.args.setArg('value', null);
+        //     expect(() => dataElem.dataElementRef).toThrowError('Value cannot be null.');
+        // });
 
         test('verify reference in created DataValueElement after assigning a BooleanDataElement with TrueElement', () => {
-            const dataElem = new DataElement.BooleanDataElement();
-            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
-            dataElem.args.setArg('value', new ValueElement.TrueElement());
-            dataElem.onVisit();
-            const valueElement = dataElem.valueElement;
-            expect(valueElement instanceof ValueElement.BooleanDataValueElement).toBe(true);
-            expect(valueElement.getData().value).toBe(true);
-            const dataElement = valueElement.getData();
-            expect(dataElement).toEqual(dataElem.dataElementRef);
+            // const dataElem = new DataElement.BooleanDataElement();
+            // dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+            // dataElem.args.setArg('value', new ValueElement.TrueElement());
+            // dataElem.onVisit();
+            // const valueElement = dataElem.valueElement;
+            // expect(valueElement instanceof ValueElement.BooleanDataValueElement).toBe(true);
+            // expect(valueElement.getData({ symbolTable }).value).toBe(true);
+            // const dataElement = valueElement.getData({ symbolTable });
+            // expect(dataElement).toEqual(dataElem.dataElementRef);
         });
 
         test('verify reference in created DataValueElement after assigning a BooleanDataElement with FalseElement', () => {
-            const dataElem = new DataElement.BooleanDataElement();
-            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
-            dataElem.args.setArg('value', new ValueElement.FalseElement());
-            dataElem.onVisit();
-            const valueElement = dataElem.valueElement;
-            expect(valueElement instanceof ValueElement.BooleanDataValueElement).toBe(true);
-            expect(valueElement.getData().value).toBe(false);
-            const dataElement = valueElement.getData();
-            expect(dataElement).toEqual(dataElem.dataElementRef);
+            // const dataElem = new DataElement.BooleanDataElement();
+            // dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+            // dataElem.args.setArg('value', new ValueElement.FalseElement());
+            // dataElem.onVisit();
+            // const valueElement = dataElem.valueElement;
+            // expect(valueElement instanceof ValueElement.BooleanDataValueElement).toBe(true);
+            // expect(valueElement.getData({ symbolTable }).value).toBe(false);
+            // const dataElement = valueElement.getData({ symbolTable });
+            // expect(dataElement).toEqual(dataElem.dataElementRef);
         });
 
-        test('attempt to fetch TBoolean reference while assigning a null as value and expect error', () => {
-            const dataElem = new DataElement.BooleanDataElement();
-            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
-            dataElem.args.setArg('value', null);
-            expect(() => dataElem.dataElementRef).toThrowError('Value cannot be null.');
-        });
+        // test('attempt to fetch TBoolean reference while assigning a null as value and expect error', () => {
+        //     const dataElem = new DataElement.BooleanDataElement();
+        //     dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+        //     dataElem.args.setArg('value', null);
+        //     expect(() => dataElem.dataElementRef).toThrowError('Value cannot be null.');
+        // });
 
         // test('verify created ValueElement after executing a AnyDataElement', () => {
         //     const dataElem = new DataElement.AnyDataElement();

--- a/src/.prototype/syntax-core/program-elements/dataElements.test.ts
+++ b/src/.prototype/syntax-core/program-elements/dataElements.test.ts
@@ -5,11 +5,11 @@ describe('namespace DataElement', () => {
     describe('initialization and verification', () => {
         test('initialize IntDataElement with IntElement object and verify', () => {
             const dataElem = new DataElement.IntDataElement();
-            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-            dataElem.argValue = new ValueElement.IntElement(5);
+            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+            dataElem.args.setArg('value', new ValueElement.IntElement(5));
             const arg = dataElem.args.getArg('value');
             if (arg !== null) {
-                expect(arg.getData().value).toBe(5);
+                expect(arg.getData({}).value).toBe(5);
             } else {
                 throw Error('Object should not be null.');
             }
@@ -18,18 +18,18 @@ describe('namespace DataElement', () => {
         test('initialize IntDataElement with ArgumentElement object of unaccepted return-type and expect error', () => {
             expect(() => {
                 const dataElem = new DataElement.IntDataElement();
-                dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-                dataElem.argValue = new ValueElement.TrueElement();
+                dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+                dataElem.args.setArg('value', new ValueElement.TrueElement());
             }).toThrowError('"TBoolean" is not a valid type for "value".');
         });
 
         test('initialize FloatDataElement with FloatElement object and verify', () => {
             const dataElem = new DataElement.FloatDataElement();
-            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-            dataElem.argValue = new ValueElement.FloatElement(5.234);
+            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+            dataElem.args.setArg('value', new ValueElement.FloatElement(5.234));
             const arg = dataElem.args.getArg('value');
             if (arg !== null) {
-                expect(arg.getData().value).toBe(5.234);
+                expect(arg.getData({}).value).toBe(5.234);
             } else {
                 throw Error('Object should not be null.');
             }
@@ -38,18 +38,18 @@ describe('namespace DataElement', () => {
         test('initialize FloatDataElement with ArgumentElement object of unaccepted return-type and expect error', () => {
             expect(() => {
                 const dataElem = new DataElement.FloatDataElement();
-                dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-                dataElem.argValue = new ValueElement.TrueElement();
+                dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+                dataElem.args.setArg('value', new ValueElement.TrueElement());
             }).toThrowError('"TBoolean" is not a valid type for "value".');
         });
 
         test('initialize CharDataElement with CharElement object and verify', () => {
             const dataElem = new DataElement.CharDataElement();
-            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-            dataElem.argValue = new ValueElement.CharElement(97);
+            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+            dataElem.args.setArg('value', new ValueElement.CharElement(97));
             const arg = dataElem.args.getArg('value');
             if (arg !== null) {
-                expect(arg.getData().value).toBe('a');
+                expect(arg.getData({}).value).toBe('a');
             } else {
                 throw Error('Object should not be null.');
             }
@@ -58,18 +58,18 @@ describe('namespace DataElement', () => {
         test('initialize CharDataElement with ArgumentElement object of unaccepted return-type and expect error', () => {
             expect(() => {
                 const dataElem = new DataElement.CharDataElement();
-                dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-                dataElem.argValue = new ValueElement.TrueElement();
+                dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+                dataElem.args.setArg('value', new ValueElement.TrueElement());
             }).toThrowError('"TBoolean" is not a valid type for "value".');
         });
 
         test('initialize StringDataElement with StringElement object and verify', () => {
             const dataElem = new DataElement.StringDataElement();
-            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-            dataElem.argValue = new ValueElement.StringElement('string');
+            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+            dataElem.args.setArg('value', new ValueElement.StringElement('string'));
             const arg = dataElem.args.getArg('value');
             if (arg !== null) {
-                expect(arg.getData().value).toBe('string');
+                expect(arg.getData({}).value).toBe('string');
             } else {
                 throw Error('Object should not be null.');
             }
@@ -78,18 +78,18 @@ describe('namespace DataElement', () => {
         test('initialize StringDataElement with ArgumentElement object of unaccepted return-type and expect error', () => {
             expect(() => {
                 const dataElem = new DataElement.StringDataElement();
-                dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-                dataElem.argValue = new ValueElement.TrueElement();
+                dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+                dataElem.args.setArg('value', new ValueElement.TrueElement());
             }).toThrowError('"TBoolean" is not a valid type for "value".');
         });
 
         test('initialize BooleanDataElement with BooleanElement object and verify', () => {
             const dataElem = new DataElement.BooleanDataElement();
-            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-            dataElem.argValue = new ValueElement.TrueElement();
+            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+            dataElem.args.setArg('value', new ValueElement.TrueElement());
             const arg = dataElem.args.getArg('value');
             if (arg !== null) {
-                expect(arg.getData().value).toBe(true);
+                expect(arg.getData({}).value).toBe(true);
             } else {
                 throw Error('Object should not be null.');
             }
@@ -98,8 +98,8 @@ describe('namespace DataElement', () => {
         test('initialize BooleanDataElement with ArgumentElement object of unaccepted return-type and expect error', () => {
             expect(() => {
                 const dataElem = new DataElement.BooleanDataElement();
-                dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-                dataElem.argValue = new ValueElement.IntElement(5);
+                dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+                dataElem.args.setArg('value', new ValueElement.IntElement(5));
             }).toThrowError('"TInt" is not a valid type for "value".');
         });
 
@@ -119,8 +119,8 @@ describe('namespace DataElement', () => {
     describe('value element verification', () => {
         test('verify reference in created DataValueElement after assigning a IntDataElement', () => {
             const dataElem = new DataElement.IntDataElement();
-            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-            dataElem.argValue = new ValueElement.IntElement(5);
+            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+            dataElem.args.setArg('value', new ValueElement.IntElement(5));
             const valueElement = dataElem.valueElement;
             expect(valueElement instanceof ValueElement.IntDataValueElement).toBe(true);
             expect(valueElement.getData().value).toBe(5);
@@ -130,15 +130,15 @@ describe('namespace DataElement', () => {
 
         test('attempt to fetch TInt reference while assigning a null as value and expect error', () => {
             const dataElem = new DataElement.IntDataElement();
-            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-            dataElem.argValue = null;
+            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+            dataElem.args.setArg('value', null);
             expect(() => dataElem.dataElementRef).toThrowError('Value cannot be null.');
         });
 
         test('verify reference in created DataValueElement after assigning a FloatDataElement', () => {
             const dataElem = new DataElement.FloatDataElement();
-            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-            dataElem.argValue = new ValueElement.FloatElement(2.71828);
+            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+            dataElem.args.setArg('value', new ValueElement.FloatElement(2.71828));
             dataElem.onVisit();
             const valueElement = dataElem.valueElement;
             expect(valueElement instanceof ValueElement.FloatDataValueElement).toBe(true);
@@ -149,15 +149,15 @@ describe('namespace DataElement', () => {
 
         test('attempt to fetch TFloat reference while assigning a null as value and expect error', () => {
             const dataElem = new DataElement.FloatDataElement();
-            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-            dataElem.argValue = null;
+            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+            dataElem.args.setArg('value', null);
             expect(() => dataElem.dataElementRef).toThrowError('Value cannot be null.');
         });
 
         test('verify reference in created DataValueElement after assigning a CharDataElement', () => {
             const dataElem = new DataElement.CharDataElement();
-            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-            dataElem.argValue = new ValueElement.CharElement(97);
+            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+            dataElem.args.setArg('value', new ValueElement.CharElement(97));
             dataElem.onVisit();
             const valueElement = dataElem.valueElement;
             expect(valueElement instanceof ValueElement.CharDataValueElement).toBe(true);
@@ -168,15 +168,15 @@ describe('namespace DataElement', () => {
 
         test('attempt to fetch TChar reference while assigning a null as value and expect error', () => {
             const dataElem = new DataElement.CharDataElement();
-            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-            dataElem.argValue = null;
+            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+            dataElem.args.setArg('value', null);
             expect(() => dataElem.dataElementRef).toThrowError('Value cannot be null.');
         });
 
         test('verify reference in created DataValueElement after assigning a StringDataElement', () => {
             const dataElem = new DataElement.StringDataElement();
-            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-            dataElem.argValue = new ValueElement.StringElement('string');
+            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+            dataElem.args.setArg('value', new ValueElement.StringElement('string'));
             dataElem.onVisit();
             const valueElement = dataElem.valueElement;
             expect(valueElement instanceof ValueElement.StringDataValueElement).toBe(true);
@@ -187,15 +187,15 @@ describe('namespace DataElement', () => {
 
         test('attempt to fetch TString reference while assigning a null as value and expect error', () => {
             const dataElem = new DataElement.StringDataElement();
-            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-            dataElem.argValue = null;
+            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+            dataElem.args.setArg('value', null);
             expect(() => dataElem.dataElementRef).toThrowError('Value cannot be null.');
         });
 
         test('verify reference in created DataValueElement after assigning a BooleanDataElement with TrueElement', () => {
             const dataElem = new DataElement.BooleanDataElement();
-            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-            dataElem.argValue = new ValueElement.TrueElement();
+            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+            dataElem.args.setArg('value', new ValueElement.TrueElement());
             dataElem.onVisit();
             const valueElement = dataElem.valueElement;
             expect(valueElement instanceof ValueElement.BooleanDataValueElement).toBe(true);
@@ -206,8 +206,8 @@ describe('namespace DataElement', () => {
 
         test('verify reference in created DataValueElement after assigning a BooleanDataElement with FalseElement', () => {
             const dataElem = new DataElement.BooleanDataElement();
-            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-            dataElem.argValue = new ValueElement.FalseElement();
+            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+            dataElem.args.setArg('value', new ValueElement.FalseElement());
             dataElem.onVisit();
             const valueElement = dataElem.valueElement;
             expect(valueElement instanceof ValueElement.BooleanDataValueElement).toBe(true);
@@ -218,8 +218,8 @@ describe('namespace DataElement', () => {
 
         test('attempt to fetch TBoolean reference while assigning a null as value and expect error', () => {
             const dataElem = new DataElement.BooleanDataElement();
-            dataElem.argIdentifier = new ValueElement.StringElement('myBox');
-            dataElem.argValue = null;
+            dataElem.args.setArg('identifier', new ValueElement.StringElement('myBox'));
+            dataElem.args.setArg('value', null);
             expect(() => dataElem.dataElementRef).toThrowError('Value cannot be null.');
         });
 

--- a/src/.prototype/syntax-core/program-elements/dataElements.ts
+++ b/src/.prototype/syntax-core/program-elements/dataElements.ts
@@ -3,7 +3,6 @@ import { TBoolean, TChar, TFloat, TInt, TString } from '../primitiveElements';
 import { ArgumentElement, StatementElement } from '../structureElements';
 import { ValueElement } from './valueElements';
 
-type argType = ArgumentElement | null;
 type dataValueType =
     | ValueElement.IntDataValueElement
     | ValueElement.FloatDataValueElement
@@ -27,24 +26,6 @@ export namespace DataElement {
             return this._type;
         }
 
-        /** @throws Invalid argument */
-        set argIdentifier(identifier: argType) {
-            this.args.setArg('identifier', identifier);
-        }
-
-        get argIdentifier() {
-            return this.args.getArg('identifier');
-        }
-
-        /** @throws Invalid argument */
-        set argValue(value: argType) {
-            this.args.setArg('value', value);
-        }
-
-        get argValue() {
-            return this.args.getArg('value');
-        }
-
         abstract get valueElement(): dataValueType;
 
         abstract get dataElementRef(): TPrimitive;
@@ -62,11 +43,11 @@ export namespace DataElement {
         }
 
         get dataElementRef() {
-            const arg = this.argValue;
+            const arg = this.args.getArg('value');
             if (arg === null) {
                 throw Error('Value cannot be null.');
             } else {
-                return arg.getData() as TInt;
+                return (arg as ValueElement.IntElement).getData() as TInt;
             }
         }
 
@@ -83,11 +64,11 @@ export namespace DataElement {
         }
 
         get dataElementRef() {
-            const arg = this.argValue;
+            const arg = this.args.getArg('value');
             if (arg === null) {
                 throw Error('Value cannot be null.');
             } else {
-                return arg.getData() as TFloat;
+                return (arg as ValueElement.FloatElement).getData() as TFloat;
             }
         }
 
@@ -104,11 +85,11 @@ export namespace DataElement {
         }
 
         get dataElementRef() {
-            const arg = this.argValue;
+            const arg = this.args.getArg('value');
             if (arg === null) {
                 throw Error('Value cannot be null.');
             } else {
-                return arg.getData() as TChar;
+                return (arg as ValueElement.CharElement).getData() as TChar;
             }
         }
 
@@ -125,11 +106,11 @@ export namespace DataElement {
         }
 
         get dataElementRef() {
-            const arg = this.argValue;
+            const arg = this.args.getArg('value');
             if (arg === null) {
                 throw Error('Value cannot be null.');
             } else {
-                return arg.getData() as TString;
+                return (arg as ValueElement.StringElement).getData() as TString;
             }
         }
 
@@ -146,11 +127,13 @@ export namespace DataElement {
         }
 
         get dataElementRef() {
-            const arg = this.argValue;
+            const arg = this.args.getArg('value');
             if (arg === null) {
                 throw Error('Value cannot be null.');
             } else {
-                return arg.getData() as TBoolean;
+                return (arg as
+                    | ValueElement.TrueElement
+                    | ValueElement.FalseElement).getData() as TBoolean;
             }
         }
 
@@ -200,28 +183,13 @@ export namespace DataElement {
             super(elementName, false, constraints);
         }
 
-        set argCurrValue(value: dataValueType | null) {
-            this.args.setArg('currValue', value);
-        }
-
-        get argCurrValue() {
-            return this.args.getArg('currValue') as dataValueType;
-        }
-
-        set argNewValue(value: ArgumentElement | null) {
-            this.args.setArg('newValue', value);
-        }
-
-        get argNewValue() {
-            return this.args.getArg('newValue');
-        }
-
-        onVisit() {
-            const argCurr = this.argCurrValue;
-            const argNew = this.argNewValue;
-            if (argCurr !== null && argNew !== null) {
-                argCurr.getData().value = argNew.getData().value;
-            }
+        onVisit(props: {
+            args: {
+                currValue: TPrimitive;
+                newValue: TPrimitive;
+            };
+        }) {
+            props.args.currValue.value = props.args.newValue.value;
         }
     }
 

--- a/src/.prototype/syntax-core/program-elements/dataElements.ts
+++ b/src/.prototype/syntax-core/program-elements/dataElements.ts
@@ -15,7 +15,7 @@ export namespace DataElement {
         private _type: TPrimitiveName;
 
         constructor(identifier: string, type: TPrimitiveName) {
-            super(identifier, false, {
+            super(identifier, {
                 identifier: ['TString'],
                 value: [type]
             });
@@ -30,7 +30,12 @@ export namespace DataElement {
 
         abstract get dataElementRef(): TPrimitive;
 
-        abstract onVisit(): void;
+        abstract onVisit(props: {
+            args: {
+                identifier: TPrimitive;
+                value: TPrimitive;
+            };
+        }): void;
     }
 
     export class IntDataElement extends DataElement {
@@ -180,7 +185,7 @@ export namespace DataElement {
                 newValue: [TPrimitiveName];
             }
         ) {
-            super(elementName, false, constraints);
+            super(elementName, constraints);
         }
 
         onVisit(props: {

--- a/src/.prototype/syntax-core/program-elements/dataElements.ts
+++ b/src/.prototype/syntax-core/program-elements/dataElements.ts
@@ -64,9 +64,9 @@ export namespace DataElement {
         get dataElementRef() {
             const arg = this.argValue;
             if (arg === null) {
-                throw Error('Invalid argument: value cannot be null');
+                throw Error('Value cannot be null.');
             } else {
-                return arg.data as TInt;
+                return arg.getData() as TInt;
             }
         }
 
@@ -85,9 +85,9 @@ export namespace DataElement {
         get dataElementRef() {
             const arg = this.argValue;
             if (arg === null) {
-                throw Error('Invalid argument: value cannot be null');
+                throw Error('Value cannot be null.');
             } else {
-                return arg.data as TFloat;
+                return arg.getData() as TFloat;
             }
         }
 
@@ -106,9 +106,9 @@ export namespace DataElement {
         get dataElementRef() {
             const arg = this.argValue;
             if (arg === null) {
-                throw Error('Invalid argument: value cannot be null');
+                throw Error('Value cannot be null.');
             } else {
-                return arg.data as TChar;
+                return arg.getData() as TChar;
             }
         }
 
@@ -127,9 +127,9 @@ export namespace DataElement {
         get dataElementRef() {
             const arg = this.argValue;
             if (arg === null) {
-                throw Error('Invalid argument: value cannot be null');
+                throw Error('Value cannot be null.');
             } else {
-                return arg.data as TString;
+                return arg.getData() as TString;
             }
         }
 
@@ -148,9 +148,9 @@ export namespace DataElement {
         get dataElementRef() {
             const arg = this.argValue;
             if (arg === null) {
-                throw Error('Invalid argument: value cannot be null');
+                throw Error('Value cannot be null.');
             } else {
-                return arg.data as TBoolean;
+                return arg.getData() as TBoolean;
             }
         }
 
@@ -220,7 +220,7 @@ export namespace DataElement {
             const argCurr = this.argCurrValue;
             const argNew = this.argNewValue;
             if (argCurr !== null && argNew !== null) {
-                argCurr.data.value = argNew.data.value;
+                argCurr.getData().value = argNew.getData().value;
             }
         }
     }

--- a/src/.prototype/syntax-core/program-elements/dataElements.ts
+++ b/src/.prototype/syntax-core/program-elements/dataElements.ts
@@ -1,9 +1,10 @@
 import { TPrimitive, TPrimitiveName } from '../@types/primitiveTypes';
-import { TBoolean, TChar, TFloat, TInt, TString } from '../primitiveElements';
-import { ArgumentElement, StatementElement } from '../structureElements';
+import { TString } from '../primitiveElements';
+import { StatementElement } from '../structureElements';
+import { SymbolTable } from '../symbolTable';
 import { ValueElement } from './valueElements';
 
-type dataValueType =
+type TDataValue =
     | ValueElement.IntDataValueElement
     | ValueElement.FloatDataValueElement
     | ValueElement.CharDataValueElement
@@ -26,16 +27,26 @@ export namespace DataElement {
             return this._type;
         }
 
-        abstract get valueElement(): dataValueType;
+        get argIdentifier() {
+            const arg = this.args.getArg('identifier');
+            if (arg === null) {
+                throw Error('Invalid data element: missing identifier.');
+            } else {
+                return arg.getData({}) as TString;
+            }
+        }
 
-        abstract get dataElementRef(): TPrimitive;
+        abstract get valueElement(): TDataValue;
 
-        abstract onVisit(props: {
+        onVisit(props: {
             args: {
                 identifier: TPrimitive;
                 value: TPrimitive;
             };
-        }): void;
+            symbolTable: SymbolTable;
+        }) {
+            props.symbolTable.addSymbol(props.args.identifier as TString, props.args.value);
+        }
     }
 
     export class IntDataElement extends DataElement {
@@ -44,19 +55,8 @@ export namespace DataElement {
         }
 
         get valueElement() {
-            return new ValueElement.IntDataValueElement(this);
+            return new ValueElement.IntDataValueElement(this.argIdentifier);
         }
-
-        get dataElementRef() {
-            const arg = this.args.getArg('value');
-            if (arg === null) {
-                throw Error('Value cannot be null.');
-            } else {
-                return (arg as ValueElement.IntElement).getData() as TInt;
-            }
-        }
-
-        onVisit() {}
     }
 
     export class FloatDataElement extends DataElement {
@@ -65,19 +65,8 @@ export namespace DataElement {
         }
 
         get valueElement() {
-            return new ValueElement.FloatDataValueElement(this);
+            return new ValueElement.FloatDataValueElement(this.argIdentifier);
         }
-
-        get dataElementRef() {
-            const arg = this.args.getArg('value');
-            if (arg === null) {
-                throw Error('Value cannot be null.');
-            } else {
-                return (arg as ValueElement.FloatElement).getData() as TFloat;
-            }
-        }
-
-        onVisit() {}
     }
 
     export class CharDataElement extends DataElement {
@@ -86,19 +75,8 @@ export namespace DataElement {
         }
 
         get valueElement() {
-            return new ValueElement.CharDataValueElement(this);
+            return new ValueElement.CharDataValueElement(this.argIdentifier);
         }
-
-        get dataElementRef() {
-            const arg = this.args.getArg('value');
-            if (arg === null) {
-                throw Error('Value cannot be null.');
-            } else {
-                return (arg as ValueElement.CharElement).getData() as TChar;
-            }
-        }
-
-        onVisit() {}
     }
 
     export class StringDataElement extends DataElement {
@@ -107,19 +85,8 @@ export namespace DataElement {
         }
 
         get valueElement() {
-            return new ValueElement.StringDataValueElement(this);
+            return new ValueElement.StringDataValueElement(this.argIdentifier);
         }
-
-        get dataElementRef() {
-            const arg = this.args.getArg('value');
-            if (arg === null) {
-                throw Error('Value cannot be null.');
-            } else {
-                return (arg as ValueElement.StringElement).getData() as TString;
-            }
-        }
-
-        onVisit() {}
     }
 
     export class BooleanDataElement extends DataElement {
@@ -128,21 +95,8 @@ export namespace DataElement {
         }
 
         get valueElement() {
-            return new ValueElement.BooleanDataValueElement(this);
+            return new ValueElement.BooleanDataValueElement(this.argIdentifier);
         }
-
-        get dataElementRef() {
-            const arg = this.args.getArg('value');
-            if (arg === null) {
-                throw Error('Value cannot be null.');
-            } else {
-                return (arg as
-                    | ValueElement.TrueElement
-                    | ValueElement.FalseElement).getData() as TBoolean;
-            }
-        }
-
-        onVisit() {}
     }
 
     // export class AnyDataElement extends DataElement {

--- a/src/.prototype/syntax-core/program-elements/loopElements.test.ts
+++ b/src/.prototype/syntax-core/program-elements/loopElements.test.ts
@@ -6,20 +6,34 @@ describe('namespace LoopElement', () => {
         const repeatElem = new LoopElement.RepeatLoopElement();
 
         test('Repeat 3 times while expecting next instruction to be itself twice and null after 3rd iteration', () => {
-            repeatElem.argValue = new ValueElement.IntElement(3);
+            const valueElem = new ValueElement.IntElement(3);
             for (let i = 0; i < 2; i++) {
-                repeatElem.onVisit();
+                repeatElem.onVisit({
+                    args: {
+                        value: valueElem.getData()
+                    }
+                });
                 repeatElem.onExit();
                 expect(repeatElem.next).toEqual(repeatElem);
             }
-            repeatElem.onVisit();
+            repeatElem.onVisit({
+                args: {
+                    value: valueElem.getData()
+                }
+            });
             repeatElem.onExit();
             expect(repeatElem.next).toBe(null);
         });
 
-        test('Repeat with a null value and expect error', () => {
-            repeatElem.argValue = null;
-            expect(() => repeatElem.onVisit()).toThrowError('Repeat loop needs a positive value.');
+        test('Repeat with a negative value and expect error', () => {
+            const valueElem = new ValueElement.IntElement(-3);
+            expect(() =>
+                repeatElem.onVisit({
+                    args: {
+                        value: valueElem.getData()
+                    }
+                })
+            ).toThrowError('Repeat loop needs a positive value.');
         });
     });
 });

--- a/src/.prototype/syntax-core/program-elements/loopElements.test.ts
+++ b/src/.prototype/syntax-core/program-elements/loopElements.test.ts
@@ -10,7 +10,7 @@ describe('namespace LoopElement', () => {
             for (let i = 0; i < 2; i++) {
                 repeatElem.onVisit({
                     args: {
-                        value: valueElem.getData()
+                        value: valueElem.getData({})
                     }
                 });
                 repeatElem.onExit();
@@ -18,7 +18,7 @@ describe('namespace LoopElement', () => {
             }
             repeatElem.onVisit({
                 args: {
-                    value: valueElem.getData()
+                    value: valueElem.getData({})
                 }
             });
             repeatElem.onExit();
@@ -30,7 +30,7 @@ describe('namespace LoopElement', () => {
             expect(() =>
                 repeatElem.onVisit({
                     args: {
-                        value: valueElem.getData()
+                        value: valueElem.getData({})
                     }
                 })
             ).toThrowError('Repeat loop needs a positive value.');

--- a/src/.prototype/syntax-core/program-elements/loopElements.test.ts
+++ b/src/.prototype/syntax-core/program-elements/loopElements.test.ts
@@ -19,9 +19,7 @@ describe('namespace LoopElement', () => {
 
         test('Repeat with a null value and expect error', () => {
             repeatElem.argValue = null;
-            expect(() => repeatElem.onVisit()).toThrowError(
-                'Invalid argument: Repeat loop needs a positive value'
-            );
+            expect(() => repeatElem.onVisit()).toThrowError('Repeat loop needs a positive value.');
         });
     });
 });

--- a/src/.prototype/syntax-core/program-elements/loopElements.ts
+++ b/src/.prototype/syntax-core/program-elements/loopElements.ts
@@ -22,13 +22,13 @@ export namespace LoopElement {
 
         onVisit() {
             const arg = this.args.getArg('value');
-            if (arg === null || arg.data.value < 0) {
-                throw Error('Invalid argument: Repeat loop needs a positive value');
+            if (arg === null || arg.getData().value < 0) {
+                throw Error('Repeat loop needs a positive value.');
             } else {
                 // Not already repeating.
                 if (this._nextStore !== null && this._nextStore.isDummy) {
                     this._nextStore = this.next;
-                    this._counter = arg.data.value as number;
+                    this._counter = arg.getData().value as number;
                 }
             }
             this.childHead = this.getChildHead(0);

--- a/src/.prototype/syntax-core/program-elements/loopElements.ts
+++ b/src/.prototype/syntax-core/program-elements/loopElements.ts
@@ -7,7 +7,7 @@ export namespace LoopElement {
         private _counter: number = 0;
 
         constructor() {
-            super('repeat', 1, false, {
+            super('repeat', 1, {
                 value: ['TInt', 'TFloat']
             });
         }

--- a/src/.prototype/syntax-core/program-elements/loopElements.ts
+++ b/src/.prototype/syntax-core/program-elements/loopElements.ts
@@ -1,9 +1,5 @@
-import {
-    ArgumentElement,
-    BlockElement,
-    DummyElement,
-    InstructionElement
-} from '../structureElements';
+import { TPrimitive } from '../@types/primitiveTypes';
+import { BlockElement, DummyElement, InstructionElement } from '../structureElements';
 
 export namespace LoopElement {
     export class RepeatLoopElement extends BlockElement {
@@ -16,19 +12,14 @@ export namespace LoopElement {
             });
         }
 
-        set argValue(value: ArgumentElement | null) {
-            this.args.setArg('value', value);
-        }
-
-        onVisit() {
-            const arg = this.args.getArg('value');
-            if (arg === null || arg.getData().value < 0) {
+        onVisit(props: { args: { value: TPrimitive } }) {
+            if (props.args['value'].value < 0) {
                 throw Error('Repeat loop needs a positive value.');
             } else {
                 // Not already repeating.
                 if (this._nextStore !== null && this._nextStore.isDummy) {
                     this._nextStore = this.next;
-                    this._counter = arg.getData().value as number;
+                    this._counter = props.args['value'].value as number;
                 }
             }
             this.childHead = this.getChildHead(0);

--- a/src/.prototype/syntax-core/program-elements/miscellaneousElements.ts
+++ b/src/.prototype/syntax-core/program-elements/miscellaneousElements.ts
@@ -1,3 +1,4 @@
+import { TPrimitive } from '../@types/primitiveTypes';
 import { ArgumentElement, StatementElement } from '../structureElements';
 
 export namespace MiscellaneousElement {
@@ -8,18 +9,9 @@ export namespace MiscellaneousElement {
             });
         }
 
-        set argMessage(message: ArgumentElement | null) {
-            this.args.setArg('message', message);
-        }
-
         /** @todo logic to be implemented after UI is created. Currently just for demonstration. */
-        onVisit() {
-            const arg = this.args.getArg('message');
-            if (arg !== null) {
-                console.log(`" ${arg.getData().value} "`);
-            } else {
-                console.log(`" ${null} "`);
-            }
+        onVisit(props: { args: { message: TPrimitive } }) {
+            console.log(`" ${props.args['message'].value} "`);
         }
     }
 }

--- a/src/.prototype/syntax-core/program-elements/miscellaneousElements.ts
+++ b/src/.prototype/syntax-core/program-elements/miscellaneousElements.ts
@@ -16,7 +16,7 @@ export namespace MiscellaneousElement {
         onVisit() {
             const arg = this.args.getArg('message');
             if (arg !== null) {
-                console.log(`" ${arg.data.value} "`);
+                console.log(`" ${arg.getData().value} "`);
             } else {
                 console.log(`" ${null} "`);
             }

--- a/src/.prototype/syntax-core/program-elements/miscellaneousElements.ts
+++ b/src/.prototype/syntax-core/program-elements/miscellaneousElements.ts
@@ -4,7 +4,7 @@ import { ArgumentElement, StatementElement } from '../structureElements';
 export namespace MiscellaneousElement {
     export class PrintElement extends StatementElement {
         constructor() {
-            super('print', false, {
+            super('print', {
                 message: ['TInt', 'TFloat', 'TChar', 'TString', 'TBoolean']
             });
         }

--- a/src/.prototype/syntax-core/program-elements/operationElements.test.ts
+++ b/src/.prototype/syntax-core/program-elements/operationElements.test.ts
@@ -6,7 +6,7 @@ describe('arithmetic operations', () => {
         const operElem = new OperationElement.AddElement();
         operElem.argOperand_1 = new ValueElement.FloatElement(15.5);
         operElem.argOperand_2 = new ValueElement.FloatElement(4);
-        const resElem = operElem.data;
+        const resElem = operElem.getData();
         expect(resElem.type).toBe('TFloat');
         expect(resElem.value).toBe(19.5);
     });
@@ -15,7 +15,7 @@ describe('arithmetic operations', () => {
         const operElem = new OperationElement.AddElement();
         operElem.argOperand_1 = new ValueElement.FloatElement(15.5);
         operElem.argOperand_2 = new ValueElement.IntElement(4);
-        const resElem = operElem.data;
+        const resElem = operElem.getData();
         expect(resElem.type).toBe('TFloat');
         expect(resElem.value).toBe(19.5);
     });
@@ -24,14 +24,14 @@ describe('arithmetic operations', () => {
         const operElem = new OperationElement.AddElement();
         operElem.argOperand_1 = new ValueElement.FloatElement(15.5);
         operElem.argOperand_2 = null;
-        expect(() => operElem.data).toThrowError('Invalid argument: "operand_2" cannot be null');
+        expect(() => operElem.getData()).toThrowError('"operand_2" cannot be null.');
     });
 
     test('supply two valid ArgumentElements to SubtractElement and verify', () => {
         const operElem = new OperationElement.SubtractElement();
         operElem.argOperand_1 = new ValueElement.FloatElement(15.5);
         operElem.argOperand_2 = new ValueElement.FloatElement(4);
-        const resElem = operElem.data;
+        const resElem = operElem.getData();
         expect(resElem.type).toBe('TFloat');
         expect(resElem.value).toBe(11.5);
     });
@@ -40,7 +40,7 @@ describe('arithmetic operations', () => {
         const operElem = new OperationElement.MultiplyElement();
         operElem.argOperand_1 = new ValueElement.FloatElement(15.5);
         operElem.argOperand_2 = new ValueElement.FloatElement(4);
-        const resElem = operElem.data;
+        const resElem = operElem.getData();
         expect(resElem.type).toBe('TFloat');
         expect(resElem.value).toBe(62);
     });
@@ -49,7 +49,7 @@ describe('arithmetic operations', () => {
         const operElem = new OperationElement.DivideElement();
         operElem.argOperand_1 = new ValueElement.FloatElement(15.5);
         operElem.argOperand_2 = new ValueElement.FloatElement(4);
-        const resElem = operElem.data;
+        const resElem = operElem.getData();
         expect(resElem.type).toBe('TFloat');
         expect(resElem.value).toBe(3.875);
     });
@@ -58,7 +58,7 @@ describe('arithmetic operations', () => {
         const operElem = new OperationElement.ModElement();
         operElem.argOperand_1 = new ValueElement.FloatElement(15.5);
         operElem.argOperand_2 = new ValueElement.FloatElement(4);
-        const resElem = operElem.data;
+        const resElem = operElem.getData();
         expect(resElem.type).toBe('TFloat');
         expect(resElem.value).toBe(3.5);
     });
@@ -69,7 +69,7 @@ describe('relation operations', () => {
         const operElem = new OperationElement.EqualsElement();
         operElem.argOperand_1 = new ValueElement.FloatElement(15.5);
         operElem.argOperand_2 = new ValueElement.FloatElement(15.5);
-        const resElem = operElem.data;
+        const resElem = operElem.getData();
         expect(resElem.type).toBe('TBoolean');
         expect(resElem.value).toBe(true);
     });
@@ -78,7 +78,7 @@ describe('relation operations', () => {
         const operElem = new OperationElement.EqualsElement();
         operElem.argOperand_1 = new ValueElement.FloatElement(15.0);
         operElem.argOperand_2 = new ValueElement.IntElement(15);
-        const resElem = operElem.data;
+        const resElem = operElem.getData();
         expect(resElem.type).toBe('TBoolean');
         expect(resElem.value).toBe(true);
     });
@@ -87,14 +87,14 @@ describe('relation operations', () => {
         const operElem = new OperationElement.EqualsElement();
         operElem.argOperand_1 = new ValueElement.FloatElement(15.5);
         operElem.argOperand_2 = null;
-        expect(() => operElem.data).toThrowError('Invalid argument: "operand_2" cannot be null');
+        expect(() => operElem.getData()).toThrowError('"operand_2" cannot be null.');
     });
 
     test('supply two valid ArgumentElements to GreaterThanElement and verify', () => {
         const operElem = new OperationElement.GreaterThanElement();
         operElem.argOperand_1 = new ValueElement.FloatElement(15.5);
         operElem.argOperand_2 = new ValueElement.FloatElement(4);
-        const resElem = operElem.data;
+        const resElem = operElem.getData();
         expect(resElem.type).toBe('TBoolean');
         expect(resElem.value).toBe(true);
     });
@@ -103,7 +103,7 @@ describe('relation operations', () => {
         const operElem = new OperationElement.LessThanElement();
         operElem.argOperand_1 = new ValueElement.FloatElement(15.5);
         operElem.argOperand_2 = new ValueElement.FloatElement(4);
-        const resElem = operElem.data;
+        const resElem = operElem.getData();
         expect(resElem.type).toBe('TBoolean');
         expect(resElem.value).toBe(false);
     });
@@ -114,7 +114,7 @@ describe('boolean operations', () => {
         const operElem = new OperationElement.AndElement();
         operElem.argOperand_1 = new ValueElement.TrueElement();
         operElem.argOperand_2 = new ValueElement.TrueElement();
-        const resElem = operElem.data;
+        const resElem = operElem.getData();
         expect(resElem.type).toBe('TBoolean');
         expect(resElem.value).toBe(true);
     });
@@ -123,14 +123,14 @@ describe('boolean operations', () => {
         const operElem = new OperationElement.AndElement();
         operElem.argOperand_1 = new ValueElement.TrueElement();
         operElem.argOperand_2 = null;
-        expect(() => operElem.data).toThrowError('Invalid argument: "operand_2" cannot be null');
+        expect(() => operElem.getData()).toThrowError('"operand_2" cannot be null.');
     });
 
     test('supply two valid ArgumentElements to OrElement and verify', () => {
         const operElem = new OperationElement.OrElement();
         operElem.argOperand_1 = new ValueElement.TrueElement();
         operElem.argOperand_2 = new ValueElement.FalseElement();
-        const resElem = operElem.data;
+        const resElem = operElem.getData();
         expect(resElem.type).toBe('TBoolean');
         expect(resElem.value).toBe(true);
     });

--- a/src/.prototype/syntax-core/program-elements/operationElements.test.ts
+++ b/src/.prototype/syntax-core/program-elements/operationElements.test.ts
@@ -4,61 +4,77 @@ import { ValueElement } from './valueElements';
 describe('arithmetic operations', () => {
     test('supply two valid ArgumentElements to AddElement and verify', () => {
         const operElem = new OperationElement.AddElement();
-        operElem.argOperand_1 = new ValueElement.FloatElement(15.5);
-        operElem.argOperand_2 = new ValueElement.FloatElement(4);
-        const resElem = operElem.getData();
+        const resElem = operElem.getData({
+            args: {
+                operand_1: new ValueElement.FloatElement(15.5).getData(),
+                operand_2: new ValueElement.FloatElement(4).getData()
+            }
+        });
         expect(resElem.type).toBe('TFloat');
         expect(resElem.value).toBe(19.5);
     });
 
     test('supply one valid ArgumentElement and type-castable ArgumentElement to AddElement and verify', () => {
         const operElem = new OperationElement.AddElement();
-        operElem.argOperand_1 = new ValueElement.FloatElement(15.5);
-        operElem.argOperand_2 = new ValueElement.IntElement(4);
-        const resElem = operElem.getData();
+        const resElem = operElem.getData({
+            args: {
+                operand_1: new ValueElement.FloatElement(15.5).getData(),
+                operand_2: new ValueElement.IntElement(4).getData()
+            }
+        });
         expect(resElem.type).toBe('TFloat');
         expect(resElem.value).toBe(19.5);
     });
 
-    test('supply one valid ArgumentElement and a null to AddElement and verify', () => {
-        const operElem = new OperationElement.AddElement();
-        operElem.argOperand_1 = new ValueElement.FloatElement(15.5);
-        operElem.argOperand_2 = null;
-        expect(() => operElem.getData()).toThrowError('"operand_2" cannot be null.');
-    });
+    // test('supply one valid ArgumentElement and a null to AddElement and verify', () => {
+    //     const operElem = new OperationElement.AddElement();
+    //     expect(() => operElem.getData({})).toThrowError('"operand_2" cannot be null.');
+    // });
 
     test('supply two valid ArgumentElements to SubtractElement and verify', () => {
         const operElem = new OperationElement.SubtractElement();
-        operElem.argOperand_1 = new ValueElement.FloatElement(15.5);
-        operElem.argOperand_2 = new ValueElement.FloatElement(4);
-        const resElem = operElem.getData();
+        const resElem = operElem.getData({
+            args: {
+                operand_1: new ValueElement.FloatElement(15.5).getData(),
+                operand_2: new ValueElement.FloatElement(4).getData()
+            }
+        });
         expect(resElem.type).toBe('TFloat');
         expect(resElem.value).toBe(11.5);
     });
 
     test('supply two valid ArgumentElements to MultiplyElement and verify', () => {
         const operElem = new OperationElement.MultiplyElement();
-        operElem.argOperand_1 = new ValueElement.FloatElement(15.5);
-        operElem.argOperand_2 = new ValueElement.FloatElement(4);
-        const resElem = operElem.getData();
+        const resElem = operElem.getData({
+            args: {
+                operand_1: new ValueElement.FloatElement(15.5).getData(),
+                operand_2: new ValueElement.FloatElement(4).getData()
+            }
+        });
         expect(resElem.type).toBe('TFloat');
         expect(resElem.value).toBe(62);
     });
 
     test('supply two valid ArgumentElements to DivideElement and verify', () => {
         const operElem = new OperationElement.DivideElement();
-        operElem.argOperand_1 = new ValueElement.FloatElement(15.5);
-        operElem.argOperand_2 = new ValueElement.FloatElement(4);
-        const resElem = operElem.getData();
+        const resElem = operElem.getData({
+            args: {
+                operand_1: new ValueElement.FloatElement(15.5).getData(),
+                operand_2: new ValueElement.FloatElement(4).getData()
+            }
+        });
         expect(resElem.type).toBe('TFloat');
         expect(resElem.value).toBe(3.875);
     });
 
     test('supply two valid ArgumentElements to ModElement and verify', () => {
         const operElem = new OperationElement.ModElement();
-        operElem.argOperand_1 = new ValueElement.FloatElement(15.5);
-        operElem.argOperand_2 = new ValueElement.FloatElement(4);
-        const resElem = operElem.getData();
+        const resElem = operElem.getData({
+            args: {
+                operand_1: new ValueElement.FloatElement(15.5).getData(),
+                operand_2: new ValueElement.FloatElement(4).getData()
+            }
+        });
         expect(resElem.type).toBe('TFloat');
         expect(resElem.value).toBe(3.5);
     });
@@ -67,43 +83,55 @@ describe('arithmetic operations', () => {
 describe('relation operations', () => {
     test('supply two valid ArgumentElements to EqualsElement and verify', () => {
         const operElem = new OperationElement.EqualsElement();
-        operElem.argOperand_1 = new ValueElement.FloatElement(15.5);
-        operElem.argOperand_2 = new ValueElement.FloatElement(15.5);
-        const resElem = operElem.getData();
+        const resElem = operElem.getData({
+            args: {
+                operand_1: new ValueElement.FloatElement(15.5).getData(),
+                operand_2: new ValueElement.FloatElement(15.5).getData()
+            }
+        });
         expect(resElem.type).toBe('TBoolean');
         expect(resElem.value).toBe(true);
     });
 
     test('supply one valid ArgumentElement and type-castable ArgumentElement to EqualsElement and verify', () => {
         const operElem = new OperationElement.EqualsElement();
-        operElem.argOperand_1 = new ValueElement.FloatElement(15.0);
-        operElem.argOperand_2 = new ValueElement.IntElement(15);
-        const resElem = operElem.getData();
+        const resElem = operElem.getData({
+            args: {
+                operand_1: new ValueElement.FloatElement(15.0).getData(),
+                operand_2: new ValueElement.IntElement(15).getData()
+            }
+        });
         expect(resElem.type).toBe('TBoolean');
         expect(resElem.value).toBe(true);
     });
 
-    test('supply one valid ArgumentElement and a null to EqualsElement and verify', () => {
-        const operElem = new OperationElement.EqualsElement();
-        operElem.argOperand_1 = new ValueElement.FloatElement(15.5);
-        operElem.argOperand_2 = null;
-        expect(() => operElem.getData()).toThrowError('"operand_2" cannot be null.');
-    });
+    // test('supply one valid ArgumentElement and a null to EqualsElement and verify', () => {
+    //     const operElem = new OperationElement.EqualsElement();
+    //     operElem.argOperand_1 = new ValueElement.FloatElement(15.5);
+    //     operElem.argOperand_2 = null;
+    //     expect(() => operElem.getData({})).toThrowError('"operand_2" cannot be null.');
+    // });
 
     test('supply two valid ArgumentElements to GreaterThanElement and verify', () => {
         const operElem = new OperationElement.GreaterThanElement();
-        operElem.argOperand_1 = new ValueElement.FloatElement(15.5);
-        operElem.argOperand_2 = new ValueElement.FloatElement(4);
-        const resElem = operElem.getData();
+        const resElem = operElem.getData({
+            args: {
+                operand_1: new ValueElement.FloatElement(15.5).getData(),
+                operand_2: new ValueElement.FloatElement(4).getData()
+            }
+        });
         expect(resElem.type).toBe('TBoolean');
         expect(resElem.value).toBe(true);
     });
 
     test('supply two valid ArgumentElements to LessThanElement and verify', () => {
         const operElem = new OperationElement.LessThanElement();
-        operElem.argOperand_1 = new ValueElement.FloatElement(15.5);
-        operElem.argOperand_2 = new ValueElement.FloatElement(4);
-        const resElem = operElem.getData();
+        const resElem = operElem.getData({
+            args: {
+                operand_1: new ValueElement.FloatElement(15.5).getData(),
+                operand_2: new ValueElement.FloatElement(4).getData()
+            }
+        });
         expect(resElem.type).toBe('TBoolean');
         expect(resElem.value).toBe(false);
     });
@@ -112,25 +140,31 @@ describe('relation operations', () => {
 describe('boolean operations', () => {
     test('supply two valid ArgumentElements to AndElement and verify', () => {
         const operElem = new OperationElement.AndElement();
-        operElem.argOperand_1 = new ValueElement.TrueElement();
-        operElem.argOperand_2 = new ValueElement.TrueElement();
-        const resElem = operElem.getData();
+        const resElem = operElem.getData({
+            args: {
+                operand_1: new ValueElement.TrueElement().getData(),
+                operand_2: new ValueElement.TrueElement().getData()
+            }
+        });
         expect(resElem.type).toBe('TBoolean');
         expect(resElem.value).toBe(true);
     });
 
-    test('supply one valid ArgumentElement and a null to EqualsElement and verify', () => {
-        const operElem = new OperationElement.AndElement();
-        operElem.argOperand_1 = new ValueElement.TrueElement();
-        operElem.argOperand_2 = null;
-        expect(() => operElem.getData()).toThrowError('"operand_2" cannot be null.');
-    });
+    // test('supply one valid ArgumentElement and a null to EqualsElement and verify', () => {
+    //     const operElem = new OperationElement.AndElement();
+    //     operElem.argOperand_1 = new ValueElement.TrueElement();
+    //     operElem.argOperand_2 = null;
+    //     expect(() => operElem.getData()).toThrowError('"operand_2" cannot be null.');
+    // });
 
     test('supply two valid ArgumentElements to OrElement and verify', () => {
         const operElem = new OperationElement.OrElement();
-        operElem.argOperand_1 = new ValueElement.TrueElement();
-        operElem.argOperand_2 = new ValueElement.FalseElement();
-        const resElem = operElem.getData();
+        const resElem = operElem.getData({
+            args: {
+                operand_1: new ValueElement.TrueElement().getData(),
+                operand_2: new ValueElement.FalseElement().getData()
+            }
+        });
         expect(resElem.type).toBe('TBoolean');
         expect(resElem.value).toBe(true);
     });

--- a/src/.prototype/syntax-core/program-elements/operationElements.test.ts
+++ b/src/.prototype/syntax-core/program-elements/operationElements.test.ts
@@ -6,8 +6,8 @@ describe('arithmetic operations', () => {
         const operElem = new OperationElement.AddElement();
         const resElem = operElem.getData({
             args: {
-                operand_1: new ValueElement.FloatElement(15.5).getData(),
-                operand_2: new ValueElement.FloatElement(4).getData()
+                operand_1: new ValueElement.FloatElement(15.5).getData({}),
+                operand_2: new ValueElement.FloatElement(4).getData({})
             }
         });
         expect(resElem.type).toBe('TFloat');
@@ -18,8 +18,8 @@ describe('arithmetic operations', () => {
         const operElem = new OperationElement.AddElement();
         const resElem = operElem.getData({
             args: {
-                operand_1: new ValueElement.FloatElement(15.5).getData(),
-                operand_2: new ValueElement.IntElement(4).getData()
+                operand_1: new ValueElement.FloatElement(15.5).getData({}),
+                operand_2: new ValueElement.IntElement(4).getData({})
             }
         });
         expect(resElem.type).toBe('TFloat');
@@ -35,8 +35,8 @@ describe('arithmetic operations', () => {
         const operElem = new OperationElement.SubtractElement();
         const resElem = operElem.getData({
             args: {
-                operand_1: new ValueElement.FloatElement(15.5).getData(),
-                operand_2: new ValueElement.FloatElement(4).getData()
+                operand_1: new ValueElement.FloatElement(15.5).getData({}),
+                operand_2: new ValueElement.FloatElement(4).getData({})
             }
         });
         expect(resElem.type).toBe('TFloat');
@@ -47,8 +47,8 @@ describe('arithmetic operations', () => {
         const operElem = new OperationElement.MultiplyElement();
         const resElem = operElem.getData({
             args: {
-                operand_1: new ValueElement.FloatElement(15.5).getData(),
-                operand_2: new ValueElement.FloatElement(4).getData()
+                operand_1: new ValueElement.FloatElement(15.5).getData({}),
+                operand_2: new ValueElement.FloatElement(4).getData({})
             }
         });
         expect(resElem.type).toBe('TFloat');
@@ -59,8 +59,8 @@ describe('arithmetic operations', () => {
         const operElem = new OperationElement.DivideElement();
         const resElem = operElem.getData({
             args: {
-                operand_1: new ValueElement.FloatElement(15.5).getData(),
-                operand_2: new ValueElement.FloatElement(4).getData()
+                operand_1: new ValueElement.FloatElement(15.5).getData({}),
+                operand_2: new ValueElement.FloatElement(4).getData({})
             }
         });
         expect(resElem.type).toBe('TFloat');
@@ -71,8 +71,8 @@ describe('arithmetic operations', () => {
         const operElem = new OperationElement.ModElement();
         const resElem = operElem.getData({
             args: {
-                operand_1: new ValueElement.FloatElement(15.5).getData(),
-                operand_2: new ValueElement.FloatElement(4).getData()
+                operand_1: new ValueElement.FloatElement(15.5).getData({}),
+                operand_2: new ValueElement.FloatElement(4).getData({})
             }
         });
         expect(resElem.type).toBe('TFloat');
@@ -85,8 +85,8 @@ describe('relation operations', () => {
         const operElem = new OperationElement.EqualsElement();
         const resElem = operElem.getData({
             args: {
-                operand_1: new ValueElement.FloatElement(15.5).getData(),
-                operand_2: new ValueElement.FloatElement(15.5).getData()
+                operand_1: new ValueElement.FloatElement(15.5).getData({}),
+                operand_2: new ValueElement.FloatElement(15.5).getData({})
             }
         });
         expect(resElem.type).toBe('TBoolean');
@@ -97,8 +97,8 @@ describe('relation operations', () => {
         const operElem = new OperationElement.EqualsElement();
         const resElem = operElem.getData({
             args: {
-                operand_1: new ValueElement.FloatElement(15.0).getData(),
-                operand_2: new ValueElement.IntElement(15).getData()
+                operand_1: new ValueElement.FloatElement(15.0).getData({}),
+                operand_2: new ValueElement.IntElement(15).getData({})
             }
         });
         expect(resElem.type).toBe('TBoolean');
@@ -116,8 +116,8 @@ describe('relation operations', () => {
         const operElem = new OperationElement.GreaterThanElement();
         const resElem = operElem.getData({
             args: {
-                operand_1: new ValueElement.FloatElement(15.5).getData(),
-                operand_2: new ValueElement.FloatElement(4).getData()
+                operand_1: new ValueElement.FloatElement(15.5).getData({}),
+                operand_2: new ValueElement.FloatElement(4).getData({})
             }
         });
         expect(resElem.type).toBe('TBoolean');
@@ -128,8 +128,8 @@ describe('relation operations', () => {
         const operElem = new OperationElement.LessThanElement();
         const resElem = operElem.getData({
             args: {
-                operand_1: new ValueElement.FloatElement(15.5).getData(),
-                operand_2: new ValueElement.FloatElement(4).getData()
+                operand_1: new ValueElement.FloatElement(15.5).getData({}),
+                operand_2: new ValueElement.FloatElement(4).getData({})
             }
         });
         expect(resElem.type).toBe('TBoolean');
@@ -142,8 +142,8 @@ describe('boolean operations', () => {
         const operElem = new OperationElement.AndElement();
         const resElem = operElem.getData({
             args: {
-                operand_1: new ValueElement.TrueElement().getData(),
-                operand_2: new ValueElement.TrueElement().getData()
+                operand_1: new ValueElement.TrueElement().getData({}),
+                operand_2: new ValueElement.TrueElement().getData({})
             }
         });
         expect(resElem.type).toBe('TBoolean');
@@ -154,15 +154,15 @@ describe('boolean operations', () => {
     //     const operElem = new OperationElement.AndElement();
     //     operElem.argOperand_1 = new ValueElement.TrueElement();
     //     operElem.argOperand_2 = null;
-    //     expect(() => operElem.getData()).toThrowError('"operand_2" cannot be null.');
+    //     expect(() => operElem.getData({})).toThrowError('"operand_2" cannot be null.');
     // });
 
     test('supply two valid ArgumentElements to OrElement and verify', () => {
         const operElem = new OperationElement.OrElement();
         const resElem = operElem.getData({
             args: {
-                operand_1: new ValueElement.TrueElement().getData(),
-                operand_2: new ValueElement.FalseElement().getData()
+                operand_1: new ValueElement.TrueElement().getData({}),
+                operand_2: new ValueElement.FalseElement().getData({})
             }
         });
         expect(resElem.type).toBe('TBoolean');

--- a/src/.prototype/syntax-core/program-elements/operationElements.ts
+++ b/src/.prototype/syntax-core/program-elements/operationElements.ts
@@ -19,7 +19,7 @@ export namespace OperationElement {
             operator: TArithOp | TRelnOp | TBoolOp,
             constraints: { operand_1: TPrimitiveName[]; operand_2: TPrimitiveName[] }
         ) {
-            super(elementName, type, false, constraints);
+            super(elementName, type, constraints);
             this._operator = operator;
         }
 

--- a/src/.prototype/syntax-core/program-elements/operationElements.ts
+++ b/src/.prototype/syntax-core/program-elements/operationElements.ts
@@ -41,7 +41,9 @@ export namespace OperationElement {
             return this._operand_2;
         }
 
-        abstract getData(): TPrimitive;
+        abstract getData(props: {
+            args: { operand_1: TPrimitive; operand_2: TPrimitive };
+        }): TPrimitive;
     }
 
     // -- Arithmetic Operators ---------------------------------------------------------------------
@@ -54,54 +56,44 @@ export namespace OperationElement {
             });
         }
 
-        getData(): TPrimitive {
-            if (this._operand_1 === null) {
-                throw Error(`"operand_1" cannot be null.`);
-            }
-            if (this._operand_2 === null) {
-                throw Error(`"operand_2" cannot be null.`);
-            }
-            if (
-                !(
-                    this._operand_1.getData() instanceof TInt ||
-                    this._operand_1.getData() instanceof TFloat
-                )
-            ) {
+        getData(props: {
+            args: {
+                operand_1: TPrimitive;
+                operand_2: TPrimitive;
+            };
+        }): TPrimitive {
+            if (!(props.args.operand_1 instanceof TInt || props.args.operand_1 instanceof TFloat)) {
                 throw Error(`"operand_1" can only be of type TInt or TFloat.`);
             }
-            if (
-                !(
-                    this._operand_2.getData() instanceof TInt ||
-                    this._operand_2.getData() instanceof TFloat
-                )
-            ) {
+            if (!(props.args.operand_2 instanceof TInt || props.args.operand_2 instanceof TFloat)) {
                 throw Error(`"operand_2" can only be of type TInt or TFloat.`);
             }
+
             switch (this._operator) {
                 case '+':
                     return TFloat.add(
-                        this._operand_1.getData() as TInt | TFloat,
-                        this._operand_2.getData() as TInt | TFloat
+                        props.args.operand_1 as TInt | TFloat,
+                        props.args.operand_2 as TInt | TFloat
                     );
                 case '-':
                     return TFloat.subtract(
-                        this._operand_1.getData() as TInt | TFloat,
-                        this._operand_2.getData() as TInt | TFloat
+                        props.args.operand_1 as TInt | TFloat,
+                        props.args.operand_2 as TInt | TFloat
                     );
                 case '*':
                     return TFloat.multiply(
-                        this._operand_1.getData() as TInt | TFloat,
-                        this._operand_2.getData() as TInt | TFloat
+                        props.args.operand_1 as TInt | TFloat,
+                        props.args.operand_2 as TInt | TFloat
                     );
                 case '/':
                     return TFloat.divide(
-                        this._operand_1.getData() as TInt | TFloat,
-                        this._operand_2.getData() as TInt | TFloat
+                        props.args.operand_1 as TInt | TFloat,
+                        props.args.operand_2 as TInt | TFloat
                     );
                 case '%':
                     return TFloat.mod(
-                        this._operand_1.getData() as TInt | TFloat,
-                        this._operand_2.getData() as TInt | TFloat
+                        props.args.operand_1 as TInt | TFloat,
+                        props.args.operand_2 as TInt | TFloat
                     );
                 default:
                     throw Error(`Should not be reached.`);
@@ -149,44 +141,34 @@ export namespace OperationElement {
             });
         }
 
-        getData(): TBoolean {
-            if (this._operand_1 === null) {
-                throw Error(`"operand_1" cannot be null.`);
-            }
-            if (this._operand_2 === null) {
-                throw Error(`"operand_2" cannot be null.`);
-            }
-            if (
-                !(
-                    this._operand_1.getData() instanceof TInt ||
-                    this._operand_1.getData() instanceof TFloat
-                )
-            ) {
+        getData(props: {
+            args: {
+                operand_1: TPrimitive;
+                operand_2: TPrimitive;
+            };
+        }): TPrimitive {
+            if (!(props.args.operand_1 instanceof TInt || props.args.operand_1 instanceof TFloat)) {
                 throw Error(`"operand_1" can only be of type TInt or TFloat.`);
             }
-            if (
-                !(
-                    this._operand_2.getData() instanceof TInt ||
-                    this._operand_2.getData() instanceof TFloat
-                )
-            ) {
+            if (!(props.args.operand_2 instanceof TInt || props.args.operand_2 instanceof TFloat)) {
                 throw Error(`"operand_2" can only be of type TInt or TFloat.`);
             }
+
             switch (this._operator) {
                 case '==':
                     return TFloat.equals(
-                        this._operand_1.getData() as TInt | TFloat,
-                        this._operand_2.getData() as TInt | TFloat
+                        props.args.operand_1 as TInt | TFloat,
+                        props.args.operand_2 as TInt | TFloat
                     );
                 case '>':
                     return TFloat.greaterThan(
-                        this._operand_1.getData() as TInt | TFloat,
-                        this._operand_2.getData() as TInt | TFloat
+                        props.args.operand_1 as TInt | TFloat,
+                        props.args.operand_2 as TInt | TFloat
                     );
                 case '<':
                     return TFloat.lessThan(
-                        this._operand_1.getData() as TInt | TFloat,
-                        this._operand_2.getData() as TInt | TFloat
+                        props.args.operand_1 as TInt | TFloat,
+                        props.args.operand_2 as TInt | TFloat
                     );
                 default:
                     throw Error(`Should not be reached.`);
@@ -222,29 +204,29 @@ export namespace OperationElement {
             });
         }
 
-        getData(): TBoolean {
-            if (this._operand_1 === null) {
-                throw Error(`"operand_1" cannot be null.`);
-            }
-            if (this._operand_2 === null) {
-                throw Error(`"operand_2" cannot be null.`);
-            }
-            if (!(this._operand_1.getData() instanceof TBoolean)) {
+        getData(props: {
+            args: {
+                operand_1: TPrimitive;
+                operand_2: TPrimitive;
+            };
+        }): TPrimitive {
+            if (!(props.args.operand_1 instanceof TBoolean)) {
                 throw Error(`"operand_1" can only be of type TBoolean.`);
             }
-            if (!(this._operand_2.getData() instanceof TBoolean)) {
+            if (!(props.args.operand_2 instanceof TBoolean)) {
                 throw Error(`"operand_2" can only be of type TBoolean.`);
             }
+
             switch (this._operator) {
                 case '&&':
                     return TBoolean.and(
-                        this._operand_1.getData() as TBoolean,
-                        this._operand_2.getData() as TBoolean
+                        props.args.operand_1 as TBoolean,
+                        props.args.operand_2 as TBoolean
                     );
                 case '||':
                     return TBoolean.or(
-                        this._operand_1.getData() as TBoolean,
-                        this._operand_2.getData() as TBoolean
+                        props.args.operand_1 as TBoolean,
+                        props.args.operand_2 as TBoolean
                     );
                 default:
                     throw Error(`Should not be reached.`);

--- a/src/.prototype/syntax-core/program-elements/operationElements.ts
+++ b/src/.prototype/syntax-core/program-elements/operationElements.ts
@@ -41,7 +41,7 @@ export namespace OperationElement {
             return this._operand_2;
         }
 
-        abstract get data(): TPrimitive;
+        abstract getData(): TPrimitive;
     }
 
     // -- Arithmetic Operators ---------------------------------------------------------------------
@@ -54,32 +54,57 @@ export namespace OperationElement {
             });
         }
 
-        get data(): TPrimitive {
+        getData(): TPrimitive {
             if (this._operand_1 === null) {
-                throw Error(`Invalid argument: "operand_1" cannot be null`);
+                throw Error(`"operand_1" cannot be null.`);
             }
             if (this._operand_2 === null) {
-                throw Error(`Invalid argument: "operand_2" cannot be null`);
+                throw Error(`"operand_2" cannot be null.`);
             }
-            if (!(this._operand_1.data instanceof TInt || this._operand_1.data instanceof TFloat)) {
-                throw Error(`Invalid argument: "operand_1" can only be of type TInt or TFloat`);
+            if (
+                !(
+                    this._operand_1.getData() instanceof TInt ||
+                    this._operand_1.getData() instanceof TFloat
+                )
+            ) {
+                throw Error(`"operand_1" can only be of type TInt or TFloat.`);
             }
-            if (!(this._operand_2.data instanceof TInt || this._operand_2.data instanceof TFloat)) {
-                throw Error(`Invalid argument: "operand_2" can only be of type TInt or TFloat`);
+            if (
+                !(
+                    this._operand_2.getData() instanceof TInt ||
+                    this._operand_2.getData() instanceof TFloat
+                )
+            ) {
+                throw Error(`"operand_2" can only be of type TInt or TFloat.`);
             }
             switch (this._operator) {
                 case '+':
-                    return TFloat.add(this._operand_1.data, this._operand_2.data);
+                    return TFloat.add(
+                        this._operand_1.getData() as TInt | TFloat,
+                        this._operand_2.getData() as TInt | TFloat
+                    );
                 case '-':
-                    return TFloat.subtract(this._operand_1.data, this._operand_2.data);
+                    return TFloat.subtract(
+                        this._operand_1.getData() as TInt | TFloat,
+                        this._operand_2.getData() as TInt | TFloat
+                    );
                 case '*':
-                    return TFloat.multiply(this._operand_1.data, this._operand_2.data);
+                    return TFloat.multiply(
+                        this._operand_1.getData() as TInt | TFloat,
+                        this._operand_2.getData() as TInt | TFloat
+                    );
                 case '/':
-                    return TFloat.divide(this._operand_1.data, this._operand_2.data);
+                    return TFloat.divide(
+                        this._operand_1.getData() as TInt | TFloat,
+                        this._operand_2.getData() as TInt | TFloat
+                    );
                 case '%':
-                    return TFloat.mod(this._operand_1.data, this._operand_2.data);
+                    return TFloat.mod(
+                        this._operand_1.getData() as TInt | TFloat,
+                        this._operand_2.getData() as TInt | TFloat
+                    );
                 default:
-                    throw Error(`Invalid access: this should not be reachable`);
+                    throw Error(`Should not be reached.`);
             }
         }
     }
@@ -124,28 +149,47 @@ export namespace OperationElement {
             });
         }
 
-        get data(): TBoolean {
+        getData(): TBoolean {
             if (this._operand_1 === null) {
-                throw Error(`Invalid argument: "operand_1" cannot be null`);
+                throw Error(`"operand_1" cannot be null.`);
             }
             if (this._operand_2 === null) {
-                throw Error(`Invalid argument: "operand_2" cannot be null`);
+                throw Error(`"operand_2" cannot be null.`);
             }
-            if (!(this._operand_1.data instanceof TInt || this._operand_1.data instanceof TFloat)) {
-                throw Error(`Invalid argument: "operand_1" can only be of type TInt or TFloat`);
+            if (
+                !(
+                    this._operand_1.getData() instanceof TInt ||
+                    this._operand_1.getData() instanceof TFloat
+                )
+            ) {
+                throw Error(`"operand_1" can only be of type TInt or TFloat.`);
             }
-            if (!(this._operand_2.data instanceof TInt || this._operand_2.data instanceof TFloat)) {
-                throw Error(`Invalid argument: "operand_2" can only be of type TInt or TFloat`);
+            if (
+                !(
+                    this._operand_2.getData() instanceof TInt ||
+                    this._operand_2.getData() instanceof TFloat
+                )
+            ) {
+                throw Error(`"operand_2" can only be of type TInt or TFloat.`);
             }
             switch (this._operator) {
                 case '==':
-                    return TFloat.equals(this._operand_1.data, this._operand_2.data);
+                    return TFloat.equals(
+                        this._operand_1.getData() as TInt | TFloat,
+                        this._operand_2.getData() as TInt | TFloat
+                    );
                 case '>':
-                    return TFloat.greaterThan(this._operand_1.data, this._operand_2.data);
+                    return TFloat.greaterThan(
+                        this._operand_1.getData() as TInt | TFloat,
+                        this._operand_2.getData() as TInt | TFloat
+                    );
                 case '<':
-                    return TFloat.lessThan(this._operand_1.data, this._operand_2.data);
+                    return TFloat.lessThan(
+                        this._operand_1.getData() as TInt | TFloat,
+                        this._operand_2.getData() as TInt | TFloat
+                    );
                 default:
-                    throw Error(`Invalid access: this should not be reachable`);
+                    throw Error(`Should not be reached.`);
             }
         }
     }
@@ -178,26 +222,32 @@ export namespace OperationElement {
             });
         }
 
-        get data(): TBoolean {
+        getData(): TBoolean {
             if (this._operand_1 === null) {
-                throw Error(`Invalid argument: "operand_1" cannot be null`);
+                throw Error(`"operand_1" cannot be null.`);
             }
             if (this._operand_2 === null) {
-                throw Error(`Invalid argument: "operand_2" cannot be null`);
+                throw Error(`"operand_2" cannot be null.`);
             }
-            if (!(this._operand_1.data instanceof TBoolean)) {
-                throw Error(`Invalid argument: "operand_1" can only be of type TBoolean`);
+            if (!(this._operand_1.getData() instanceof TBoolean)) {
+                throw Error(`"operand_1" can only be of type TBoolean.`);
             }
-            if (!(this._operand_2.data instanceof TBoolean)) {
-                throw Error(`Invalid argument: "operand_2" can only be of type TBoolean`);
+            if (!(this._operand_2.getData() instanceof TBoolean)) {
+                throw Error(`"operand_2" can only be of type TBoolean.`);
             }
             switch (this._operator) {
                 case '&&':
-                    return TBoolean.and(this._operand_1.data, this._operand_2.data);
+                    return TBoolean.and(
+                        this._operand_1.getData() as TBoolean,
+                        this._operand_2.getData() as TBoolean
+                    );
                 case '||':
-                    return TBoolean.or(this._operand_1.data, this._operand_2.data);
+                    return TBoolean.or(
+                        this._operand_1.getData() as TBoolean,
+                        this._operand_2.getData() as TBoolean
+                    );
                 default:
-                    throw Error(`Invalid access: this should not be reachable`);
+                    throw Error(`Should not be reached.`);
             }
         }
     }

--- a/src/.prototype/syntax-core/program-elements/valueElements.test.ts
+++ b/src/.prototype/syntax-core/program-elements/valueElements.test.ts
@@ -9,47 +9,47 @@ describe('namespace ValueElement', () => {
     describe('instantiation and value verification', () => {
         test('instantiate a IntElement with 5 and expect 5 to be data', () => {
             intValElem = new ValueElement.IntElement(5);
-            expect(intValElem.data.value).toBe(5);
+            expect(intValElem.getData().value).toBe(5);
         });
         test('instantiate a FloatElement with 2.71828 and expect 2.71828 to be data', () => {
             floatValElem = new ValueElement.FloatElement(2.71828);
-            expect(floatValElem.data.value).toBe(2.71828);
+            expect(floatValElem.getData().value).toBe(2.71828);
         });
         test('instantiate a CharElement with 97 and expect "a" to be data', () => {
             charValElem = new ValueElement.CharElement(97);
-            expect(charValElem.data.value).toBe('a');
+            expect(charValElem.getData().value).toBe('a');
         });
         test('instantiate a StringElement with "string" and expect "string" to be data', () => {
             stringValElem = new ValueElement.StringElement('string');
-            expect(stringValElem.data.value).toBe('string');
+            expect(stringValElem.getData().value).toBe('string');
         });
         test('instantiate a TrueElement and expect true to be data', () => {
-            expect(new ValueElement.TrueElement().data.value).toBe(true);
+            expect(new ValueElement.TrueElement().getData().value).toBe(true);
         });
         test('instantiate a FalseElement and expect false to be data', () => {
-            expect(new ValueElement.FalseElement().data.value).toBe(false);
+            expect(new ValueElement.FalseElement().getData().value).toBe(false);
         });
     });
 
     describe('value updation', () => {
         test('update IntElement value to 2 and expect 2 to be data', () => {
             intValElem.update(2);
-            expect(intValElem.data.value).toBe(2);
+            expect(intValElem.getData().value).toBe(2);
         });
 
         test('update FloatElement value to 3.1415 and expect 3.1415 to be data', () => {
             floatValElem.update(3.1415);
-            expect(floatValElem.data.value).toBe(3.1415);
+            expect(floatValElem.getData().value).toBe(3.1415);
         });
 
         test('update CharElement value to "x" and expect "x" to be data', () => {
             charValElem.update('x');
-            expect(charValElem.data.value).toBe('x');
+            expect(charValElem.getData().value).toBe('x');
         });
 
         test('update StringElement value to "another" and expect "another" to be data', () => {
             stringValElem.update('another');
-            expect(stringValElem.data.value).toBe('another');
+            expect(stringValElem.getData().value).toBe('another');
         });
     });
 });

--- a/src/.prototype/syntax-core/program-elements/valueElements.test.ts
+++ b/src/.prototype/syntax-core/program-elements/valueElements.test.ts
@@ -9,47 +9,47 @@ describe('namespace ValueElement', () => {
     describe('instantiation and value verification', () => {
         test('instantiate a IntElement with 5 and expect 5 to be data', () => {
             intValElem = new ValueElement.IntElement(5);
-            expect(intValElem.getData().value).toBe(5);
+            expect(intValElem.getData({}).value).toBe(5);
         });
         test('instantiate a FloatElement with 2.71828 and expect 2.71828 to be data', () => {
             floatValElem = new ValueElement.FloatElement(2.71828);
-            expect(floatValElem.getData().value).toBe(2.71828);
+            expect(floatValElem.getData({}).value).toBe(2.71828);
         });
         test('instantiate a CharElement with 97 and expect "a" to be data', () => {
             charValElem = new ValueElement.CharElement(97);
-            expect(charValElem.getData().value).toBe('a');
+            expect(charValElem.getData({}).value).toBe('a');
         });
         test('instantiate a StringElement with "string" and expect "string" to be data', () => {
             stringValElem = new ValueElement.StringElement('string');
-            expect(stringValElem.getData().value).toBe('string');
+            expect(stringValElem.getData({}).value).toBe('string');
         });
         test('instantiate a TrueElement and expect true to be data', () => {
-            expect(new ValueElement.TrueElement().getData().value).toBe(true);
+            expect(new ValueElement.TrueElement().getData({}).value).toBe(true);
         });
         test('instantiate a FalseElement and expect false to be data', () => {
-            expect(new ValueElement.FalseElement().getData().value).toBe(false);
+            expect(new ValueElement.FalseElement().getData({}).value).toBe(false);
         });
     });
 
     describe('value updation', () => {
         test('update IntElement value to 2 and expect 2 to be data', () => {
             intValElem.update(2);
-            expect(intValElem.getData().value).toBe(2);
+            expect(intValElem.getData({}).value).toBe(2);
         });
 
         test('update FloatElement value to 3.1415 and expect 3.1415 to be data', () => {
             floatValElem.update(3.1415);
-            expect(floatValElem.getData().value).toBe(3.1415);
+            expect(floatValElem.getData({}).value).toBe(3.1415);
         });
 
         test('update CharElement value to "x" and expect "x" to be data', () => {
             charValElem.update('x');
-            expect(charValElem.getData().value).toBe('x');
+            expect(charValElem.getData({}).value).toBe('x');
         });
 
         test('update StringElement value to "another" and expect "another" to be data', () => {
             stringValElem.update('another');
-            expect(stringValElem.getData().value).toBe('another');
+            expect(stringValElem.getData({}).value).toBe('another');
         });
     });
 });

--- a/src/.prototype/syntax-core/program-elements/valueElements.ts
+++ b/src/.prototype/syntax-core/program-elements/valueElements.ts
@@ -19,7 +19,7 @@ export namespace ValueElement {
         private _data: TPrimitive;
 
         constructor(elementName: string, data: TPrimitive) {
-            super(elementName, data.type, false);
+            super(elementName, data.type);
             this._data = data;
         }
 
@@ -91,7 +91,7 @@ export namespace ValueElement {
         private _dataElementRef: dataElemType;
 
         constructor(elementName: string, dataElement: dataElemType) {
-            super(elementName, dataElement.type, false);
+            super(elementName, dataElement.type);
             this._dataElementRef = dataElement;
         }
 

--- a/src/.prototype/syntax-core/program-elements/valueElements.ts
+++ b/src/.prototype/syntax-core/program-elements/valueElements.ts
@@ -19,11 +19,11 @@ export namespace ValueElement {
         private _data: TPrimitive;
 
         constructor(elementName: string, data: TPrimitive) {
-            super(elementName, data.type);
+            super(elementName, data.type, false);
             this._data = data;
         }
 
-        get data() {
+        getData() {
             return this._data;
         }
     }
@@ -35,7 +35,7 @@ export namespace ValueElement {
         }
 
         update(value: number) {
-            this.data.value = value;
+            this.getData().value = value;
         }
     }
 
@@ -46,7 +46,7 @@ export namespace ValueElement {
         }
 
         update(value: number) {
-            this.data.value = value;
+            this.getData().value = value;
         }
     }
 
@@ -57,7 +57,7 @@ export namespace ValueElement {
         }
 
         update(value: string | number) {
-            this.data.value = value;
+            this.getData().value = value;
         }
     }
 
@@ -68,7 +68,7 @@ export namespace ValueElement {
         }
 
         update(value: string) {
-            this.data.value = value;
+            this.getData().value = value;
         }
     }
 
@@ -90,12 +90,12 @@ export namespace ValueElement {
         private _dataElementRef: dataElemType;
 
         constructor(elementName: string, dataElement: dataElemType) {
-            super(elementName, dataElement.type);
+            super(elementName, dataElement.type, false);
             this._dataElementRef = dataElement;
         }
 
         /** @override */
-        get data() {
+        getData() {
             return this._dataElementRef.dataElementRef;
         }
     }

--- a/src/.prototype/syntax-core/program-elements/valueElements.ts
+++ b/src/.prototype/syntax-core/program-elements/valueElements.ts
@@ -1,9 +1,10 @@
 import { TPrimitive } from '../@types/primitiveTypes';
 import { TInt, TFloat, TChar, TString, TBoolean } from '../primitiveElements';
 import { ArgumentDataElement } from '../structureElements';
+import { SymbolTable } from '../symbolTable';
 import { DataElement } from './dataElements';
 
-type dataElemType =
+type TDataElem =
     | DataElement.IntDataElement
     | DataElement.FloatDataElement
     | DataElement.CharDataElement
@@ -16,7 +17,7 @@ type dataElemType =
  */
 export namespace ValueElement {
     abstract class ValueElement extends ArgumentDataElement {
-        private _data: TPrimitive;
+        protected _data: TPrimitive;
 
         constructor(elementName: string, data: TPrimitive) {
             super(elementName, data.type);
@@ -24,7 +25,7 @@ export namespace ValueElement {
         }
 
         /** @override */
-        getData() {
+        getData(props: { symbolTable?: SymbolTable }) {
             return this._data;
         }
     }
@@ -36,7 +37,7 @@ export namespace ValueElement {
         }
 
         update(value: number) {
-            this.getData().value = value;
+            this._data.value = value;
         }
     }
 
@@ -47,7 +48,7 @@ export namespace ValueElement {
         }
 
         update(value: number) {
-            this.getData().value = value;
+            this._data.value = value;
         }
     }
 
@@ -58,7 +59,7 @@ export namespace ValueElement {
         }
 
         update(value: string | number) {
-            this.getData().value = value;
+            this._data.value = value;
         }
     }
 
@@ -69,7 +70,7 @@ export namespace ValueElement {
         }
 
         update(value: string) {
-            this.getData().value = value;
+            this._data.value = value;
         }
     }
 
@@ -87,47 +88,48 @@ export namespace ValueElement {
         }
     }
 
-    abstract class DataValueElement extends ArgumentDataElement {
-        private _dataElementRef: dataElemType;
+    abstract class DataValueElement extends ValueElement {
+        constructor(elementName: string, symbol: TString) {
+            super(elementName, symbol);
+        }
 
-        constructor(elementName: string, dataElement: dataElemType) {
-            super(elementName, dataElement.type);
-            this._dataElementRef = dataElement;
+        update(value: string) {
+            this._data.value = value;
         }
 
         /** @override */
-        getData() {
-            return this._dataElementRef.dataElementRef;
+        getData(props: { symbolTable: SymbolTable }) {
+            return props.symbolTable.getSymbolData(this._data as TString);
         }
     }
 
     export class IntDataValueElement extends DataValueElement {
-        constructor(dataElement: DataElement.IntDataElement) {
-            super('data-value-int', dataElement);
+        constructor(symbol: TString) {
+            super('data-value-int', symbol);
         }
     }
 
     export class FloatDataValueElement extends DataValueElement {
-        constructor(dataElement: DataElement.FloatDataElement) {
-            super('data-value-float', dataElement);
+        constructor(symbol: TString) {
+            super('data-value-float', symbol);
         }
     }
 
     export class CharDataValueElement extends DataValueElement {
-        constructor(dataElement: DataElement.CharDataElement) {
-            super('data-value-char', dataElement);
+        constructor(symbol: TString) {
+            super('data-value-char', symbol);
         }
     }
 
     export class StringDataValueElement extends DataValueElement {
-        constructor(dataElement: DataElement.StringDataElement) {
-            super('data-value-string', dataElement);
+        constructor(symbol: TString) {
+            super('data-value-string', symbol);
         }
     }
 
     export class BooleanDataValueElement extends DataValueElement {
-        constructor(dataElement: DataElement.BooleanDataElement) {
-            super('data-value-boolean', dataElement);
+        constructor(symbol: TString) {
+            super('data-value-boolean', symbol);
         }
     }
 }

--- a/src/.prototype/syntax-core/program-elements/valueElements.ts
+++ b/src/.prototype/syntax-core/program-elements/valueElements.ts
@@ -23,6 +23,7 @@ export namespace ValueElement {
             this._data = data;
         }
 
+        /** @override */
         getData() {
             return this._data;
         }

--- a/src/.prototype/syntax-core/structureElements.test.ts
+++ b/src/.prototype/syntax-core/structureElements.test.ts
@@ -8,13 +8,13 @@ import {
 
 /** Dummy class to extend abstract class ArgumentDataElement. */
 class CArgumentDataElement extends ArgumentDataElement {
-    get data() {
+    getData() {
         return new TInt(5);
     }
 }
 /** Dummy class to extend abstract class ArgumentExpressionElement. */
 class CArgumentExpressionElement extends ArgumentExpressionElement {
-    get data() {
+    getData() {
         return new TInt(5);
     }
 }
@@ -33,21 +33,21 @@ let argExpr: ArgumentExpressionElement;
 
 describe('class ArgumentDataElement', () => {
     test("intialize dummy ArgumentDataElement's subclass with valid arbitrary arguments and verify contents", () => {
-        argData = new CArgumentDataElement('myArgData', 'TInt');
+        argData = new CArgumentDataElement('myArgData', 'TInt', false);
         expect(argData.elementName).toBe('myArgData');
         expect(argData.type).toBe('TInt');
         expect(argData.argType).toBe('data');
-        expect(argData.data.value).toBe(5);
+        expect(argData.getData().value).toBe(5);
     });
 });
 
 describe('class ArgumentExpressionElement', () => {
     test("initialize dummy ArgumentExpressionElement's subclass with valid arbitrary arguments and verify contents", () => {
-        argExpr = new CArgumentExpressionElement('myArgExpression', 'TInt');
+        argExpr = new CArgumentExpressionElement('myArgExpression', 'TInt', false);
         expect(argExpr.elementName).toBe('myArgExpression');
         expect(argExpr.type).toBe('TInt');
         expect(argExpr.argType).toBe('expression');
-        expect(argExpr.data.value).toBe(5);
+        expect(argExpr.getData().value).toBe(5);
     });
 });
 
@@ -55,9 +55,9 @@ let stmntElem: StatementElement;
 
 describe('class StatementElement', () => {
     test('initialize object with no argument constraints and expect error on fetching argument labels', () => {
-        stmntElem = new CStatementElement('yourStatement');
-        expect(() => stmntElem.args.argNames).toThrowError(
-            `Invalid access: instruction "yourStatement" does not take arguments`
+        stmntElem = new CStatementElement('yourStatement', false);
+        expect(() => stmntElem.args.argLabels).toThrowError(
+            `"yourStatement" does not take arguments.`
         );
     });
 
@@ -67,7 +67,7 @@ describe('class StatementElement', () => {
             arg_2: ['TString']
         });
         try {
-            expect(stmntElem.args.argNames).toEqual(['arg_1', 'arg_2']);
+            expect(stmntElem.args.argLabels).toEqual(['arg_1', 'arg_2']);
         } catch (e) {
             console.error(e);
         }
@@ -78,7 +78,7 @@ describe('class StatementElement', () => {
             stmntElem.args.setArg('arg_1', argData);
             const arg = stmntElem.args.getArg('arg_1');
             if (arg !== null) {
-                expect(arg.data.value).toEqual(5);
+                expect(arg.getData().value).toEqual(5);
             }
         } catch (e) {
             console.error(e);
@@ -96,19 +96,19 @@ describe('class StatementElement', () => {
 
     test('try to fetch argument for invalid argument label and expect error', () => {
         expect(() => stmntElem.args.getArg('arg_3')).toThrowError(
-            'Invalid argument: "arg_3" does not exist for instruction "myStatement"'
+            '"arg_3" does not exist for "myStatement".'
         );
     });
 
     test('try to assign argument for invalid argument label and expect error', () => {
         expect(() => stmntElem.args.setArg('arg_3', null)).toThrowError(
-            'Invalid argument: "arg_3" does not exist for instruction "myStatement"'
+            '"arg_3" does not exist for "myStatement".'
         );
     });
 
     test('try to assign invalid return-type argument for valid argument label and expect error', () => {
         expect(() => stmntElem.args.setArg('arg_2', argData)).toThrowError(
-            'Invalid argument: "TInt" is not a valid type for "arg_2"'
+            '"TInt" is not a valid type for "arg_2".'
         );
     });
 });
@@ -120,7 +120,7 @@ describe('class BlockElement', () => {
         blockElem = new CBlockElement('myBlock', 1, false, { arg_1: ['TBoolean'] });
         expect(blockElem.next).toBe(null);
         if (blockElem.args !== null) {
-            expect(blockElem.args.argNames).toEqual(['arg_1']);
+            expect(blockElem.args.argLabels).toEqual(['arg_1']);
         } else {
             throw Error('object should not be null');
         }

--- a/src/.prototype/syntax-core/structureElements.test.ts
+++ b/src/.prototype/syntax-core/structureElements.test.ts
@@ -33,7 +33,7 @@ let argExpr: ArgumentExpressionElement;
 
 describe('class ArgumentDataElement', () => {
     test("intialize dummy ArgumentDataElement's subclass with valid arbitrary arguments and verify contents", () => {
-        argData = new CArgumentDataElement('myArgData', 'TInt', false);
+        argData = new CArgumentDataElement('myArgData', 'TInt');
         expect(argData.elementName).toBe('myArgData');
         expect(argData.type).toBe('TInt');
         expect(argData.argType).toBe('data');
@@ -43,7 +43,7 @@ describe('class ArgumentDataElement', () => {
 
 describe('class ArgumentExpressionElement', () => {
     test("initialize dummy ArgumentExpressionElement's subclass with valid arbitrary arguments and verify contents", () => {
-        argExpr = new CArgumentExpressionElement('myArgExpression', 'TInt', false);
+        argExpr = new CArgumentExpressionElement('myArgExpression', 'TInt');
         expect(argExpr.elementName).toBe('myArgExpression');
         expect(argExpr.type).toBe('TInt');
         expect(argExpr.argType).toBe('expression');
@@ -55,14 +55,14 @@ let stmntElem: StatementElement;
 
 describe('class StatementElement', () => {
     test('initialize object with no argument constraints and expect error on fetching argument labels', () => {
-        stmntElem = new CStatementElement('yourStatement', false);
+        stmntElem = new CStatementElement('yourStatement');
         expect(() => stmntElem.args.argLabels).toThrowError(
             `"yourStatement" does not take arguments.`
         );
     });
 
     test('initialize object with argument constraints and verify initial contents', () => {
-        stmntElem = new CStatementElement('myStatement', false, {
+        stmntElem = new CStatementElement('myStatement', {
             arg_1: ['TInt', 'TChar'],
             arg_2: ['TString']
         });
@@ -117,7 +117,7 @@ describe('class BlockElement', () => {
     let blockElem: BlockElement;
 
     test('initialize object with argument constraints and verify initial contents', () => {
-        blockElem = new CBlockElement('myBlock', 1, false, { arg_1: ['TBoolean'] });
+        blockElem = new CBlockElement('myBlock', 1, { arg_1: ['TBoolean'] });
         expect(blockElem.next).toBe(null);
         if (blockElem.args !== null) {
             expect(blockElem.args.argLabels).toEqual(['arg_1']);

--- a/src/.prototype/syntax-core/structureElements.test.ts
+++ b/src/.prototype/syntax-core/structureElements.test.ts
@@ -37,7 +37,7 @@ describe('class ArgumentDataElement', () => {
         expect(argData.elementName).toBe('myArgData');
         expect(argData.type).toBe('TInt');
         expect(argData.argType).toBe('data');
-        expect(argData.getData().value).toBe(5);
+        expect(argData.getData({}).value).toBe(5);
     });
 });
 
@@ -47,7 +47,7 @@ describe('class ArgumentExpressionElement', () => {
         expect(argExpr.elementName).toBe('myArgExpression');
         expect(argExpr.type).toBe('TInt');
         expect(argExpr.argType).toBe('expression');
-        expect(argExpr.getData().value).toBe(5);
+        expect(argExpr.getData({}).value).toBe(5);
     });
 });
 
@@ -78,7 +78,7 @@ describe('class StatementElement', () => {
             stmntElem.args.setArg('arg_1', argData);
             const arg = stmntElem.args.getArg('arg_1');
             if (arg !== null) {
-                expect(arg.getData().value).toEqual(5);
+                expect(arg.getData({}).value).toEqual(5);
             }
         } catch (e) {
             console.error(e);

--- a/src/.prototype/syntax-core/structureElements.ts
+++ b/src/.prototype/syntax-core/structureElements.ts
@@ -111,7 +111,7 @@ export abstract class ArgumentElement extends SyntaxElement implements TS.IArgum
         elementName: string,
         argType: 'data' | 'expression',
         type: TPrimitiveName,
-        requiresContext?: boolean
+        requiresContext: boolean
     ) {
         super(elementName, requiresContext);
         this._argType = argType;
@@ -126,7 +126,10 @@ export abstract class ArgumentElement extends SyntaxElement implements TS.IArgum
         return this._type;
     }
 
-    abstract getData(context?: Context): TPrimitive;
+    abstract getData(props: {
+        context?: Context;
+        args?: { [key: string]: TPrimitive };
+    }): TPrimitive;
 }
 
 export abstract class ArgumentDataElement
@@ -167,6 +170,7 @@ export abstract class InstructionElement extends SyntaxElement implements TS.IIn
     constructor(
         elementName: string,
         requiresContext: boolean,
+        // Certain instructions might not take arguments, instead could work on the context.
         constraints?: { [key: string]: TPrimitiveName[] }
     ) {
         super(elementName, requiresContext);
@@ -186,15 +190,15 @@ export abstract class InstructionElement extends SyntaxElement implements TS.IIn
     }
 
     /** Executes when element is encountered by MB program interpretor. */
-    abstract onVisit(context?: Context): void;
+    abstract onVisit(props: { context?: Context; args?: { [key: string]: TPrimitive } }): void;
 
-    /** Whether current instruction is a dummy instruction */
+    /** Whether current instruction is a dummy instruction. */
     get isDummy() {
         return this.elementName === 'dummy';
     }
 }
 
-/** To be treated as a terminating or non-existing instruction */
+/** To be treated as a terminating or non-existing instruction. */
 export class DummyElement extends InstructionElement {
     constructor() {
         super('dummy', false);
@@ -252,6 +256,7 @@ export abstract class BlockElement extends InstructionElement implements TS.IBlo
         return this._childHeads[index];
     }
 
+    /** @param childHead must always be one of the values of `_childHeads`. */
     set childHead(childHead: InstructionElement | null) {
         this._childHead = childHead;
     }
@@ -261,5 +266,5 @@ export abstract class BlockElement extends InstructionElement implements TS.IBlo
     }
 
     /** Executes after instructions inside the block have been executed. */
-    abstract onExit(context?: Context): void;
+    abstract onExit(props: { context?: Context; args?: { [key: string]: TPrimitive } }): void;
 }

--- a/src/.prototype/syntax-core/structureElements.ts
+++ b/src/.prototype/syntax-core/structureElements.ts
@@ -10,19 +10,13 @@ import { Context } from './context';
  */
 export abstract class SyntaxElement implements TS.ISyntaxElement {
     private _elementName: string;
-    private _requiresContext: boolean;
 
-    constructor(elementName: string, requiresContext: boolean) {
+    constructor(elementName: string) {
         this._elementName = elementName;
-        this._requiresContext = requiresContext;
     }
 
     get elementName() {
         return this._elementName;
-    }
-
-    get requiresContext() {
-        return this._requiresContext;
     }
 }
 
@@ -107,13 +101,8 @@ export abstract class ArgumentElement extends SyntaxElement implements TS.IArgum
     private _argType: 'data' | 'expression';
     private _type: TPrimitiveName;
 
-    constructor(
-        elementName: string,
-        argType: 'data' | 'expression',
-        type: TPrimitiveName,
-        requiresContext: boolean
-    ) {
-        super(elementName, requiresContext);
+    constructor(elementName: string, argType: 'data' | 'expression', type: TPrimitiveName) {
+        super(elementName);
         this._argType = argType;
         this._type = type;
     }
@@ -135,8 +124,8 @@ export abstract class ArgumentElement extends SyntaxElement implements TS.IArgum
 export abstract class ArgumentDataElement
     extends ArgumentElement
     implements TS.IArgumentDataElement {
-    constructor(elementName: string, type: TPrimitiveName, requiresContext: boolean) {
-        super(elementName, 'data', type, requiresContext);
+    constructor(elementName: string, type: TPrimitiveName) {
+        super(elementName, 'data', type);
     }
 }
 
@@ -148,11 +137,10 @@ export abstract class ArgumentExpressionElement
     constructor(
         elementName: string,
         type: TPrimitiveName,
-        requiresContext: boolean,
         // Certain argument expressions might not take arguments, instead could work on the context.
         constraints?: { [key: string]: TPrimitiveName[] }
     ) {
-        super(elementName, 'expression', type, requiresContext);
+        super(elementName, 'expression', type);
         this._args = new ArgumentMap(elementName, !constraints ? null : constraints);
     }
 
@@ -169,11 +157,10 @@ export abstract class InstructionElement extends SyntaxElement implements TS.IIn
 
     constructor(
         elementName: string,
-        requiresContext: boolean,
         // Certain instructions might not take arguments, instead could work on the context.
         constraints?: { [key: string]: TPrimitiveName[] }
     ) {
-        super(elementName, requiresContext);
+        super(elementName);
         this._args = new ArgumentMap(elementName, !constraints ? null : constraints);
     }
 
@@ -201,19 +188,15 @@ export abstract class InstructionElement extends SyntaxElement implements TS.IIn
 /** To be treated as a terminating or non-existing instruction. */
 export class DummyElement extends InstructionElement {
     constructor() {
-        super('dummy', false);
+        super('dummy');
     }
 
     onVisit() {}
 }
 
 export abstract class StatementElement extends InstructionElement implements TS.IStatementElement {
-    constructor(
-        elementName: string,
-        requiresContext: boolean,
-        constraints?: { [key: string]: TPrimitiveName[] }
-    ) {
-        super(elementName, requiresContext, constraints);
+    constructor(elementName: string, constraints?: { [key: string]: TPrimitiveName[] }) {
+        super(elementName, constraints);
     }
 }
 
@@ -226,10 +209,9 @@ export abstract class BlockElement extends InstructionElement implements TS.IBlo
     constructor(
         elementName: string,
         blocksCount: number,
-        requiresContext: boolean,
         constraints?: { [key: string]: TPrimitiveName[] }
     ) {
-        super(elementName, requiresContext, constraints);
+        super(elementName, constraints);
         if (blocksCount < 1) {
             throw Error('Number of inner blocks cannot be less than 1.');
         }

--- a/src/.prototype/syntax-core/structureElements.ts
+++ b/src/.prototype/syntax-core/structureElements.ts
@@ -1,6 +1,7 @@
 import { TPrimitiveName, TPrimitive } from './@types/primitiveTypes';
 import * as TS from './@types/structureElements';
 import { Context } from './context';
+import { SymbolTable } from './symbolTable';
 
 // ---- Syntax Element -----------------------------------------------------------------------------
 
@@ -116,8 +117,9 @@ export abstract class ArgumentElement extends SyntaxElement implements TS.IArgum
     }
 
     abstract getData(props: {
-        context?: Context;
         args?: { [key: string]: TPrimitive };
+        context?: Context;
+        symbolTable?: SymbolTable;
     }): TPrimitive;
 }
 
@@ -177,7 +179,11 @@ export abstract class InstructionElement extends SyntaxElement implements TS.IIn
     }
 
     /** Executes when element is encountered by MB program interpretor. */
-    abstract onVisit(props: { context?: Context; args?: { [key: string]: TPrimitive } }): void;
+    abstract onVisit(props: {
+        args?: { [key: string]: TPrimitive };
+        context?: Context;
+        symbolTable?: SymbolTable;
+    }): void;
 
     /** Whether current instruction is a dummy instruction. */
     get isDummy() {
@@ -248,5 +254,9 @@ export abstract class BlockElement extends InstructionElement implements TS.IBlo
     }
 
     /** Executes after instructions inside the block have been executed. */
-    abstract onExit(props: { context?: Context; args?: { [key: string]: TPrimitive } }): void;
+    abstract onExit(props: {
+        args?: { [key: string]: TPrimitive };
+        context?: Context;
+        symbolTable?: SymbolTable;
+    }): void;
 }

--- a/src/.prototype/syntax-core/symbolTable.ts
+++ b/src/.prototype/syntax-core/symbolTable.ts
@@ -1,0 +1,38 @@
+import { TPrimitive, TPrimitiveName } from './@types/primitiveTypes';
+import { ISymbolTable } from './@types/symbolTable';
+import { TBoolean, TString } from './primitiveElements';
+
+export class SymbolTable implements ISymbolTable {
+    private _table: {
+        [key: string]: {
+            type: TPrimitiveName;
+            data: TPrimitive;
+        };
+    } = {};
+
+    constructor() {}
+
+    symbolExists(symbol: TString) {
+        return new TBoolean(symbol.value in this._table);
+    }
+
+    addSymbol(symbol: TString, data: TPrimitive) {
+        if (symbol.value in this._table) {
+            throw Error(`Duplicate symbol: symbol "${symbol.value}" already exists.`);
+        }
+        this._table[symbol.value] = {
+            type: data.type,
+            data
+        };
+    }
+
+    getSymbolData(symbol: TString) {
+        if (!(symbol.value in this._table)) {
+            throw Error(`Invalid symbol: symbol "${symbol}" does not exist.`);
+        }
+        return (this._table[symbol.value] as {
+            type: TPrimitiveName;
+            data: TPrimitive;
+        }).data;
+    }
+}

--- a/src/.prototype/syntax-core/syntaxElementFactory.test.ts
+++ b/src/.prototype/syntax-core/syntaxElementFactory.test.ts
@@ -12,13 +12,13 @@ describe('createSyntaxElement utililty', () => {
         const elem = createSyntaxElement('int', 5);
         expect(elem.element.elementName).toBe('int');
         expect(elem.type).toBe('arg-data');
-        expect((elem.element as ValueElement.IntElement).getData().value).toBe(5);
+        expect((elem.element as ValueElement.IntElement).getData({}).value).toBe(5);
     });
 
     test('attempt to instantiate (with invalid arguments) an element that takes arguments and expect error', () => {
         expect(() => {
             const elem = createSyntaxElement('int', 'string');
-            const v = (elem.element as ValueElement.IntElement).getData();
+            const v = (elem.element as ValueElement.IntElement).getData({});
             expect(v.value).toBe('string');
         }).toThrowError('Instantiation failed: invalid argument supplied for element "int".');
     });

--- a/src/.prototype/syntax-core/syntaxElementFactory.test.ts
+++ b/src/.prototype/syntax-core/syntaxElementFactory.test.ts
@@ -5,14 +5,12 @@ describe('createSyntaxElement utililty', () => {
     test("instantiate an element that doesn't take arguments and verify object and type", () => {
         const elem = createSyntaxElement('start');
         expect(elem.element.elementName).toBe('start');
-        expect(elem.element.requiresContext).toBe(false);
         expect(elem.type).toBe('block');
     });
 
     test('instantiate (with valid arguments) an element that takes arguments and verify object and type', () => {
         const elem = createSyntaxElement('int', 5);
         expect(elem.element.elementName).toBe('int');
-        expect(elem.element.requiresContext).toBe(false);
         expect(elem.type).toBe('arg-data');
         expect((elem.element as ValueElement.IntElement).getData().value).toBe(5);
     });

--- a/src/.prototype/syntax-core/syntaxElementFactory.test.ts
+++ b/src/.prototype/syntax-core/syntaxElementFactory.test.ts
@@ -1,0 +1,33 @@
+import { createSyntaxElement } from './syntaxElementFactory';
+import { ValueElement } from './program-elements/valueElements';
+
+describe('createSyntaxElement utililty', () => {
+    test("instantiate an element that doesn't take arguments and verify object and type", () => {
+        const elem = createSyntaxElement('start');
+        expect(elem.element.elementName).toBe('start');
+        expect(elem.element.requiresContext).toBe(false);
+        expect(elem.type).toBe('block');
+    });
+
+    test('instantiate (with valid arguments) an element that takes arguments and verify object and type', () => {
+        const elem = createSyntaxElement('int', 5);
+        expect(elem.element.elementName).toBe('int');
+        expect(elem.element.requiresContext).toBe(false);
+        expect(elem.type).toBe('arg-data');
+        expect((elem.element as ValueElement.IntElement).getData().value).toBe(5);
+    });
+
+    test('attempt to instantiate (with invalid arguments) an element that takes arguments and expect error', () => {
+        expect(() => {
+            const elem = createSyntaxElement('int', 'string');
+            const v = (elem.element as ValueElement.IntElement).getData();
+            expect(v.value).toBe('string');
+        }).toThrowError('Instantiation failed: invalid argument supplied for element "int".');
+    });
+
+    test('attempt to instantiate (without arguments) an element that takes arguments and expect error', () => {
+        expect(() => createSyntaxElement('int')).toThrowError(
+            'Instantiation failed: invalid argument supplied for element "int".'
+        );
+    });
+});


### PR DESCRIPTION
- Add/Remove 'start' elements to AST
- Replace argument `data` getter with `getData` method
- Improve type implementation in syntax element factory
- Pass argument primitives and context to `onVisit`, `onExit`, and `getData`
- Create symbol table and attach functionality to data elements
- Pass symbol table to `onVisit`, `onExit`, and `getData`